### PR TITLE
Fixed issues with contacting KPs and normalizer

### DIFF
--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -54,7 +54,7 @@ class KnowledgePortal():
             output_prefixes: dict = None,
     ):
         """Wrap fetch with CURIE mapping(s)."""
-        request = await self.map_prefixes(request, input_prefixes)
+        request['message'] = await self.map_prefixes(request['message'], input_prefixes)
 
         response = await post_json(url, request)
         message = response["message"]
@@ -131,7 +131,7 @@ class Synonymizer():
                     for synonym in entity["equivalent_identifiers"]
                 ],
             )
-            for entity in response.json().values()
+            for entity in response.json().values() if entity
         ]
         self._data |= {
             curie: entity

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -16,7 +16,7 @@ import json
 from datetime import datetime
 import jsonpickle
 
-from reasoner_pydantic import QueryGraph, Result
+from reasoner_pydantic import QueryGraph, Result, Response
 
 from .query_planner import generate_plan, Step
 from .compatibility import KnowledgePortal
@@ -177,7 +177,7 @@ class StriderWorker(Worker):
 
         # Set the node ID of the current step to the
         # given curie
-        kp_request_body['query_graph']['nodes'][step.source]['id'] = curie
+        kp_request_body['message']['query_graph']['nodes'][step.source]['id'] = curie
 
         responses = await asyncio.gather(*(
             self.portal.fetch(
@@ -228,7 +228,7 @@ class StriderWorker(Worker):
 def get_kp_request_body(
         qgraph: QueryGraph,
         edge: str,
-) -> QueryGraph:
+) -> Response:
     """Get request to send to KP."""
     included_nodes = [
         qgraph['edges'][edge]['subject'],
@@ -246,4 +246,4 @@ def get_kp_request_body(
             if key in included_edges
         },
     }
-    return {"query_graph": request_qgraph}
+    return {"message": {"query_graph": request_qgraph}}

--- a/strider/util.py
+++ b/strider/util.py
@@ -80,7 +80,7 @@ class WrappedBMT():
 
 async def post_json(url, request):
     """Make post request."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(verify=False, timeout=None) as client:
         response = await client.post(
             url,
             json=request,

--- a/tests/compatibility/test_compatibility.py
+++ b/tests/compatibility/test_compatibility.py
@@ -251,7 +251,7 @@ async def test_fetch():
 
     response = await portal.fetch(
         url="http://ctd/query",
-        request={"query_graph": query_graph},
+        request={"message": {"query_graph": query_graph}},
         input_prefixes=CTD_PREFIXES,
         output_prefixes=preferred_prefixes,
     )


### PR DESCRIPTION
- Switched to contacting KPs with a Query object instead of a Message
- Validate node normalizer responses to ensure they are not None
- Added unlimited timeout for KP calls