### PR TITLE
Predicate Directionality Fix

### DIFF
--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -197,7 +197,7 @@ async def find_valid_permutations(
         # Swap subject and object
         reverse_edge['subject'], reverse_edge['object'] = \
             reverse_edge['object'], reverse_edge['subject']
-        reverse_edges[f"{edge_id}{REVERSE_EDGE_SUFFIX}"] = reverse_edge
+        reverse_edges[edge_id + REVERSE_EDGE_SUFFIX] = reverse_edge
 
         # Assign directionality to forward edge
         edge['predicate'] = [f"-{p}->" for p in edge['predicate']]

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -19,6 +19,8 @@ Step = namedtuple("Step", ["source", "edge", "target"])
 Operation = namedtuple(
     "Operation", ["source_category", "edge_predicate", "target_category"])
 
+REVERSE_EDGE_SUFFIX = '.reverse'
+
 
 def find_next_list_property(search_dict, fields_to_check):
     """ Find first object in a dictionary where object[field] is a list """
@@ -195,7 +197,7 @@ async def find_valid_permutations(
         # Swap subject and object
         reverse_edge['subject'], reverse_edge['object'] = \
             reverse_edge['object'], reverse_edge['subject']
-        reverse_edges[f"{edge_id}-reverse"] = reverse_edge
+        reverse_edges[f"{edge_id}{REVERSE_EDGE_SUFFIX}"] = reverse_edge
 
         # Assign directionality to forward edge
         edge['predicate'] = [f"-{p}->" for p in edge['predicate']]
@@ -409,8 +411,8 @@ async def generate_plans(
 
                 # Reverse edges don't actually exist, so the steps in the plan
                 # should just refer to the forward edges
-                if edge_id.endswith('-reverse'):
-                    edge_id = edge_id.replace('-reverse', '')
+                if edge_id.endswith(REVERSE_EDGE_SUFFIX):
+                    edge_id = edge_id.replace(REVERSE_EDGE_SUFFIX, '')
 
                 step = Step(edge['subject'], edge_id, edge['object'])
                 # Attach information about categorys to kp info

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -94,6 +94,33 @@ def query_graph_from_string(s):
     return qg
 
 
+def kps_from_string(s):
+    """
+    Converts a simple KP operation from a string format to JSON
+
+    Example:
+    kp0 biolink:ChemicalSubstance -biolink:treats-> biolink:Disease
+
+    """
+    s = inspect.cleandoc(s)
+    kp_re = r"(?P<name>.*) (?P<src>.*) (?P<predicate>.*) (?P<target>.*)"
+    kps = {}
+    for line in s.splitlines():
+        match_kp = re.search(kp_re, line)
+        if not match_kp:
+            raise ValueError(f"Invalid line: {line}")
+        name = match_kp.group('name')
+        kps[name] = {
+            "url": f"http://{name}",
+            "operations": [{
+                "source_type": match_kp.group('src'),
+                "edge_type": match_kp.group('predicate'),
+                "target_type": match_kp.group('target'),
+            }]
+        }
+    return kps
+
+
 async def time_and_display(f, msg):
     """ Time a function and print the time """
     start_time = time.time()

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -59,7 +59,7 @@ async def test_permute_simple(caplog):
         "edges": {
             "e01": {
                 "subject": "n0",
-                # Two children and two directions
+                # Two children
                 "predicate": "biolink:affects_abundance_of",
                 "object": "n1",
             },
@@ -71,9 +71,9 @@ async def test_permute_simple(caplog):
     assert permutations
 
     # We should have:
-    # 4 * 2 * 3 * 2 = 48
+    # 4 * 2 * 3 = 24
     # permutations
-    assert len(list(permutations)) == 48
+    assert len(list(permutations)) == 24
 
 
 simple_kp = load_kps(cwd / "simple_kp.json")

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -150,7 +150,7 @@ async def test_no_path_from_pinned_node():
 @with_norm_overlay(settings.normalizer_url)
 async def test_solve_reverse_edge():
     """
-    Test that we can solve a simple query graph 
+    Test that we can solve a simple query graph
     where we have to traverse an edge in the opposite
     direction of one that was given
     """


### PR DESCRIPTION
Fixed issue where we were not traversing predicates correctly in the reverse direction. We do this by adding edges temporarily in the planning step to ensure that we cover plans that use edges in the opposite direction.