### PR TITLE
fix for missing predicate in query graph

### DIFF
--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -115,6 +115,10 @@ class StriderWorker(Worker):
             {"query_graph": qgraph},
             self.preferred_prefixes,
         ))["query_graph"]
+        # Fill in missing predicates with most general term
+        for eid, edge in self.qgraph['edges'].items():
+            if ('predicate' not in edge) or (edge['predicate'] is None):
+                edge['predicate'] = 'biolink:related_to'
 
     async def generate_plan(self):
         """

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -95,6 +95,33 @@ async def test_solve_ex1():
         ("hetio", DEFAULT_PREFIXES),
         ("mychem", MYCHEM_PREFIXES),
     ])
+async def test_solve_missing_predicate():
+    """Test solving the ex1 query graph, in which one of the predicates is missing. """
+    with open(cwd / "ex1_qg.json", "r") as f:
+        QGRAPH = json.load(f)
+
+    del QGRAPH['edges']['e01']['predicate']
+
+    # Create query
+    q = Query(
+        message=Message(
+            query_graph=QueryGraph.parse_obj(QGRAPH)
+        )
+    )
+
+    # Run
+    output = await sync_query(q)
+
+
+@pytest.mark.asyncio
+@with_translator_overlay(
+    settings.kpregistry_url,
+    settings.normalizer_url,
+    [
+        ("ctd", CTD_PREFIXES),
+        ("hetio", DEFAULT_PREFIXES),
+        ("mychem", MYCHEM_PREFIXES),
+    ])
 async def test_log_level_param():
     """Test that changing the log level given to sync_query changes the output """
     with open(cwd / "ex1_qg.json", "r") as f:


### PR DESCRIPTION
If you send a query graph with no predicate for an edge, strider gives a 500. 

Added a little bit that replaces empty predicates with 'biolink:related_to'.

Not sure I did it in the best place, and I don't especially like hardcoding the top predicate.

But it works, and there's a test.