### PR TITLE
Verify log contents in tests

### DIFF
--- a/tests/helpers/logger.py
+++ b/tests/helpers/logger.py
@@ -40,3 +40,19 @@ def setup_logger():
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(ColoredFormatter())
     logger.addHandler(handler)
+
+
+def assert_no_level(logger, allowed_level, exceptions=0):
+    """
+    Check that the logger has no records greater than
+    the allowed level.
+
+    Also has a parameter to specify the number of exceptions
+    to the rule (number of records that will be ignored).
+    """
+    total = 0
+    for record in logger.records:
+        if record.levelno >= allowed_level:
+            total += 1
+        if total > exceptions:
+            raise Exception(f"Invalid Log Record: {record}")

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -48,6 +48,16 @@ CTD_PREFIXES = {
 }
 
 
+def assert_no_warnings_trapi(resp):
+    """
+    Check for any errors or warnings in the log of a trapi response
+    """
+    invalid_levels = ['WARNING', 'ERROR', 'CRITICAL']
+    for log in resp['logs']:
+        if log['level'] in invalid_levels:
+            raise Exception(f"Invalid log record: {log}")
+
+
 @pytest.mark.asyncio
 @with_translator_overlay(
     settings.kpregistry_url,
@@ -73,13 +83,12 @@ async def test_solve_ex1():
     output = await sync_query(q)
 
     assert output
-    # Check for any errors in the log
-    assert all(l['level'] != 'ERROR' for l in output['logs'])
     # Ensure we have some results
     assert len(output['message']['results']) > 0
     # Ensure we have a knowledge graph with nodes and edges
     assert len(output['message']['knowledge_graph']['nodes']) > 0
     assert len(output['message']['knowledge_graph']['edges']) > 0
+    assert_no_warnings_trapi(output)
 
     print("========================= RESULTS =========================")
     print(output['message']['results'])
@@ -111,6 +120,7 @@ async def test_solve_missing_predicate():
 
     # Run
     output = await sync_query(q)
+    assert_no_warnings_trapi(output)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Added utilities for verifying log contents in each test to ensure we fail tests if there are unexpected warnings or errors. 

(This should catch an issue when combined with #57 😄)