### PR TITLE
Fixed plan endpoint

### DIFF
--- a/strider/server.py
+++ b/strider/server.py
@@ -370,7 +370,7 @@ async def generate_traversal_plan(
     for plan in plans:
         plans_stringified_keys.append(
             {
-                f"{step.source}-{step.edge}->{step.target}": v
+                f"{step.source}-{step.edge}-{step.target}": v
                 for step, v in plan.items()
             }
         )

--- a/strider/server.py
+++ b/strider/server.py
@@ -8,7 +8,7 @@ import os
 import enum
 from pathlib import Path
 import pprint
-from typing import Dict
+from typing import List, Dict
 
 from fastapi import Body, Depends, FastAPI, HTTPException, BackgroundTasks
 from fastapi.openapi.docs import (
@@ -359,13 +359,23 @@ async def extract_results(query_id, since, limit, offset, database):
     ]
 
 
-@APP.post('/plan', response_model=Dict)
+@APP.post('/plan', response_model=List[Dict])
 async def generate_traversal_plan(
         query: Query,
-) -> list[Dict]:
+) -> List[Dict]:
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
-    return await generate_plans(query_graph)
+    plans = await generate_plans(query_graph)
+
+    plans_stringified_keys = []
+    for plan in plans:
+        plans_stringified_keys.append(
+            {
+                f"{step.source}-{step.edge}->{step.target}": v
+                for step, v in plan.items()
+            }
+        )
+    return plans_stringified_keys
 
 
 @APP.post('/score', response_model=Message)

--- a/strider/server.py
+++ b/strider/server.py
@@ -8,7 +8,6 @@ import os
 import enum
 from pathlib import Path
 import pprint
-from typing import List, Dict
 
 from fastapi import Body, Depends, FastAPI, HTTPException, BackgroundTasks
 from fastapi.openapi.docs import (
@@ -227,7 +226,7 @@ async def sync_query(
 
 @APP.post('/ars')
 async def handle_ars(
-        data: Dict,
+        data: dict,
 ):
     """Handle ARS message."""
     if data.get('model', None) != 'tr_ars.message':
@@ -359,10 +358,10 @@ async def extract_results(query_id, since, limit, offset, database):
     ]
 
 
-@APP.post('/plan', response_model=List[Dict])
+@APP.post('/plan', response_model=list[dict])
 async def generate_traversal_plan(
         query: Query,
-) -> List[Dict]:
+) -> list[dict]:
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
     plans = await generate_plans(query_graph)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -251,8 +251,8 @@ async def test_plan_ex1():
     plan = output[0]
 
     # Two steps in the plan each with KPs to contact
-    assert len(plan['n0-e01->n1']) == 2
-    assert len(plan['n1-e12->n2']) == 1
+    assert len(plan['n0-e01-n1']) == 2
+    assert len(plan['n1-e12-n2']) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -245,11 +245,14 @@ async def test_plan_ex1():
     output = await generate_traversal_plan(q)
     assert output
 
+    # Check that output is JSON serializeable
+    json.dumps(output)
+
     plan = output[0]
 
     # Two steps in the plan each with KPs to contact
-    assert len(plan[('n0', 'e01', 'n1')]) == 2
-    assert len(plan[('n1', 'e12', 'n2')]) == 1
+    assert len(plan['n0-e01->n1']) == 2
+    assert len(plan['n1-e12->n2']) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Plan endpoint was trying to use a tuple as a JSON key and was therefore throwing a 500 error. This replaces the tuple with a simple string key format (`n0-e01->n1`).