### PR TITLE
Fixed reverse and forward edges in plans

### DIFF
--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -110,14 +110,16 @@ def kps_from_string(s):
         if not match_kp:
             raise ValueError(f"Invalid line: {line}")
         name = match_kp.group('name')
-        kps[name] = {
-            "url": f"http://{name}",
-            "operations": [{
-                "source_type": match_kp.group('src'),
-                "edge_type": match_kp.group('predicate'),
-                "target_type": match_kp.group('target'),
-            }]
-        }
+        if name not in kps:
+            kps[name] = {
+                "url": f"http://{name}",
+                "operations": [],
+            }
+        kps[name]['operations'].append({
+            "source_type": match_kp.group('src'),
+            "edge_type": match_kp.group('predicate'),
+            "target_type": match_kp.group('target'),
+        })
     return kps
 
 

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -128,12 +128,9 @@ async def test_no_reverse_edge_in_plan(caplog):
         """
     )
 
-    log = logging.getLogger()
-    log.setLevel(logging.DEBUG)
-
     plans = await generate_plans(
         qg,
-        logger=log,
+        logger=logging.getLogger(),
     )
     plan = plans[0]
 

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -106,6 +106,45 @@ async def test_not_enough_kps(caplog):
 @pytest.mark.asyncio
 @with_registry_overlay(settings.kpregistry_url, kps_from_string(
     """
+    kp0 biolink:Disease -biolink:related_to-> biolink:Drug
+    kp0 biolink:Disease <-biolink:related_to- biolink:Drug
+    kp0 biolink:Drug <-biolink:related_to- biolink:Disease
+    kp0 biolink:Drug -biolink:related_to-> biolink:Disease
+    """
+))
+@with_norm_overlay(settings.normalizer_url)
+async def test_no_reverse_edge_in_plan(caplog):
+    """
+    Check that we don't include
+    both reverse and forward edges in plan even
+    if we have KPs that can solve both
+    """
+
+    qg = query_graph_from_string(
+        """
+        n0(( id MONDO:0005148 ))
+        n1(( category biolink:Drug ))
+        n0-- biolink:related_to -->n1
+        """
+    )
+
+    log = logging.getLogger()
+    log.setLevel(logging.DEBUG)
+
+    plans = await generate_plans(
+        qg,
+        logger=log,
+    )
+    plan = plans[0]
+
+    # One step in plan
+    assert len(plan) == 1
+    assert_no_level(caplog, logging.WARNING, 1)
+
+
+@pytest.mark.asyncio
+@with_registry_overlay(settings.kpregistry_url, kps_from_string(
+    """
     kp0 biolink:Drug -biolink:treats-> biolink:Disease
     """
 ))


### PR DESCRIPTION
Fixed issue where both forward and reverse edges were included in plans. Also updated kps_from_string method to allow multiple line definitions of a single KP.