### PR TITLE
Category Normalizer Mismatch

### DIFF
--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -74,6 +74,7 @@ class StriderWorker(Worker):
     def __init__(self, *args, **kwargs):
         """Initialize."""
         self.plan: dict[Step, list]
+        self.expanded_qg: dict[str, dict]
         self.preferred_prefixes: dict[str, list[str]]
         self.qgraph: RedisGraph
         self.kgraph: RedisGraph
@@ -140,7 +141,7 @@ class StriderWorker(Worker):
         """
         self.logger.debug("Generating plan")
         # Generate traversal plan
-        plans = await generate_plans(
+        plans, self.expanded_qg = await generate_plans(
             self.qgraph,
             kp_registry=registry,
             logger=self.logger)
@@ -154,7 +155,7 @@ class StriderWorker(Worker):
         self.logger.debug({"plan": self.plan})
 
         # add partial results for each curie that we are given
-        for qnode_id, qnode in self.qgraph["nodes"].items():
+        for qnode_id, qnode in self.expanded_qg["nodes"].items():
             if not qnode.get("id", False):
                 continue
             for curie in qnode["id"]:

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -393,10 +393,13 @@ async def generate_plans(
         kp_registry: Registry = None,
         normalizer: Normalizer = None,
         logger: logging.Logger = LOGGER,
-) -> list[dict[Step, list]]:
+) -> (list[dict[Step, list]], dict[str, dict]):
     """
     Given a query graph, build plans that consists of steps
-    and the KPs we need to contact to evaluate those steps
+    and the KPs we need to contact to evaluate those steps.
+
+    Also return the expanded query graph so that we can use it during the
+    solving process.
     """
 
     logger.debug("Generating plan for query graph")
@@ -421,7 +424,7 @@ async def generate_plans(
                     We couldn't find a KP for every edge in your query graph
                 """
         })
-        return []
+        return [], {}
 
     plans = []
 
@@ -491,7 +494,7 @@ async def generate_plans(
             """
         })
 
-    return plans
+    return plans, expanded_qg
 
 
 def validate_and_annotate_og_list(

--- a/strider/server.py
+++ b/strider/server.py
@@ -358,7 +358,7 @@ async def generate_traversal_plan(
 ) -> list[dict]:
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
-    plans = await generate_plans(query_graph)
+    plans, _ = await generate_plans(query_graph)
 
     plans_stringified_keys = []
     for plan in plans:

--- a/strider/worker.py
+++ b/strider/worker.py
@@ -32,10 +32,12 @@ class Worker(ABC):
     def __init__(
             self,
             num_workers: int = 1,
+            logger: logging.Logger = LOGGER,
             **kwargs,
     ):
         """Initialize."""
         self.num_workers = num_workers
+        self.logger = logger
 
         self.queue = asyncio.PriorityQueue()
         self.counter = itertools.count()
@@ -49,11 +51,10 @@ class Worker(ABC):
         try:
             await self.on_message(message)
         except Exception as err:
-            LOGGER.exception(
-                "Aborted processing of %s due to error: %s",
-                message,
-                str(err),
-            )
+            self.logger.exception({
+                "message": "Aborted processing of queue item due to exception",
+                "queue_item": message,
+            })
 
     async def consume(self):
         """Consume messages."""

--- a/tests/helpers/normalizer.py
+++ b/tests/helpers/normalizer.py
@@ -41,12 +41,17 @@ def generate_synset_mappings():
     }
 
 
-def norm_router():
+def norm_router(
+        synset_mappings: dict[str, list] = None,
+        category_mappings: dict[str, list] = None
+):
     """Generate node-normalization router."""
     router = APIRouter()
 
-    synset_mappings = generate_synset_mappings()
-    category_mappings = generate_category_mappings()
+    if not synset_mappings:
+        synset_mappings = generate_synset_mappings()
+    if not category_mappings:
+        category_mappings = generate_category_mappings()
 
     def normalize_one(curie):
         """Get normalizer response for CURIE."""

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -125,7 +125,7 @@ def kps_from_string(s):
     return kps
 
 
-def node_normalizer_data_from_string(s):
+def normalizer_data_from_string(s):
     """
     Parse data for node normalizer from string. Useful for tests.
 
@@ -139,28 +139,26 @@ def node_normalizer_data_from_string(s):
     # so we use inspect.cleandoc to remove leading indentation
     s = inspect.cleandoc(s)
 
-    node_re = r"(?P<id>.*)\(\( (?P<key>.*) (?P<val>.*) \)\)"
-    edge_re = r"(?P<src>.*)-- (?P<predicate>.*) -->(?P<target>.*)"
-    qg = {"nodes": {}, "edges": {}}
+    category_mappings = {}
+    synset_mappings = {}
     for line in s.splitlines():
-        match_node = re.search(node_re, line)
-        match_edge = re.search(edge_re, line)
-        if match_node:
-            node_id = match_node.group('id')
-            if node_id not in qg['nodes']:
-                qg['nodes'][node_id] = {}
-            qg['nodes'][node_id][match_node.group('key')] = \
-                match_node.group('val')
-        elif match_edge:
-            edge_id = match_edge.group('src') + match_edge.group('target')
-            qg['edges'][edge_id] = {
-                "subject": match_edge.group('src'),
-                "object": match_edge.group('target'),
-                "predicate": match_edge.group('predicate'),
-            }
+        tokens = line.split(" ")
+
+        curie = tokens[0]
+        if curie not in category_mappings:
+            category_mappings[curie] = []
+        if curie not in synset_mappings:
+            synset_mappings[curie] = []
+
+        action = tokens[1]
+        line_data = tokens[2:]
+        if action == 'categories':
+            category_mappings[curie].extend(line_data)
+        elif action == 'synonyms':
+            synset_mappings[curie].extend(line_data)
         else:
             raise ValueError(f"Invalid line: {line}")
-    return qg
+    return {"category_mappings": category_mappings, "synset_mappings": synset_mappings}
 
 
 async def time_and_display(f, msg):

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import itertools
 import time
 import json
@@ -139,17 +140,12 @@ def normalizer_data_from_string(s):
     # so we use inspect.cleandoc to remove leading indentation
     s = inspect.cleandoc(s)
 
-    category_mappings = {}
-    synset_mappings = {}
+    category_mappings = defaultdict(list)
+    synset_mappings = defaultdict(list)
     for line in s.splitlines():
         tokens = line.split(" ")
 
         curie = tokens[0]
-        if curie not in category_mappings:
-            category_mappings[curie] = []
-        if curie not in synset_mappings:
-            synset_mappings[curie] = []
-
         action = tokens[1]
         line_data = tokens[2:]
         if action == 'categories':

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -95,7 +95,7 @@ async def test_not_enough_kps(caplog):
         """
     )
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger()
     )
@@ -128,7 +128,7 @@ async def test_no_reverse_edge_in_plan(caplog):
         """
     )
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -167,7 +167,7 @@ async def test_no_path_from_pinned_node(caplog):
     permutations = await find_valid_permutations(operation_graph)
     assert len(list(permutations))
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -197,7 +197,7 @@ async def test_solve_reverse_edge(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -232,7 +232,7 @@ async def test_plan_ex1(caplog):
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     plan = plans[0]
     # One step per edge
     assert len(plan.keys()) == len(qg['edges'])
@@ -267,7 +267,7 @@ async def test_invalid_two_pinned_nodes(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -295,7 +295,7 @@ async def test_unbound_unconnected_node(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -324,7 +324,7 @@ async def test_invalid_two_disconnected_components(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -361,7 +361,7 @@ async def test_bad_norm(caplog):
         }
     }
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert any(
         (
             record.levelname == "WARNING"

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -150,7 +150,7 @@ async def test_duplicate_results():
 @with_translator_overlay(
     settings.kpregistry_url,
     settings.normalizer_url,
-    {
+    kp_data={
         "ctd":
         """
             CHEBI:6801(( category biolink:ChemicalSubstance ))

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -217,6 +217,50 @@ async def test_solve_missing_category():
 @with_translator_overlay(
     settings.kpregistry_url,
     settings.normalizer_url,
+    kp_data={
+        "ctd":
+        """
+            CHEBI:6801(( category biolink:Drug ))
+            MONDO:0005148(( category biolink:Disease ))
+            CHEBI:6801-- predicate biolink:treats -->MONDO:0005148
+        """
+    },
+    normalizer_data="""
+        CHEBI:6801 categories biolink:Drug
+        """
+
+)
+async def test_normalizer_different_category():
+    """
+    Test solving a query graph where the category provided doesn't match
+    the one in the node normalizer.
+    """
+
+    QGRAPH = query_graph_from_string(
+        """
+        n0(( category biolink:ChemicalSubstance ))
+        n0(( id CHEBI:6801 ))
+        n1(( category biolink:Disease ))
+        n0-- biolink:treats -->n1
+        """
+    )
+
+    # Create query
+    q = Query(
+        message=Message(
+            query_graph=QueryGraph.parse_obj(QGRAPH)
+        )
+    )
+
+    # Run
+    output = await sync_query(q)
+    assert_no_warnings_trapi(output)
+
+
+@pytest.mark.asyncio
+@with_translator_overlay(
+    settings.kpregistry_url,
+    settings.normalizer_url,
     {
         "ctd":
         """


### PR DESCRIPTION
Fixed #62 where the category given does not match the one that is in the normalizer. The fix involves passing the expanded query graph into StriderWorker and then using that for partial results. Builds on #91.