### PR TITLE
Category Normalizer Mismatch

### DIFF
--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -74,6 +74,7 @@ class StriderWorker(Worker):
     def __init__(self, *args, **kwargs):
         """Initialize."""
         self.plan: dict[Step, list]
+        self.expanded_qg: dict[str, dict]
         self.preferred_prefixes: dict[str, list[str]]
         self.qgraph: RedisGraph
         self.kgraph: RedisGraph
@@ -140,7 +141,7 @@ class StriderWorker(Worker):
         """
         self.logger.debug("Generating plan")
         # Generate traversal plan
-        plans = await generate_plans(
+        plans, self.expanded_qg = await generate_plans(
             self.qgraph,
             kp_registry=registry,
             logger=self.logger)
@@ -154,7 +155,7 @@ class StriderWorker(Worker):
         self.logger.debug({"plan": self.plan})
 
         # add partial results for each curie that we are given
-        for qnode_id, qnode in self.qgraph["nodes"].items():
+        for qnode_id, qnode in self.expanded_qg["nodes"].items():
             if not qnode.get("id", False):
                 continue
             for curie in qnode["id"]:

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -393,10 +393,13 @@ async def generate_plans(
         kp_registry: Registry = None,
         normalizer: Normalizer = None,
         logger: logging.Logger = LOGGER,
-) -> list[dict[Step, list]]:
+) -> (list[dict[Step, list]], dict[str, dict]):
     """
     Given a query graph, build plans that consists of steps
-    and the KPs we need to contact to evaluate those steps
+    and the KPs we need to contact to evaluate those steps.
+
+    Also return the expanded query graph so that we can use it during the
+    solving process.
     """
 
     logger.debug("Generating plan for query graph")
@@ -421,7 +424,7 @@ async def generate_plans(
                     We couldn't find a KP for every edge in your query graph
                 """
         })
-        return []
+        return [], {}
 
     plans = []
 
@@ -491,7 +494,7 @@ async def generate_plans(
             """
         })
 
-    return plans
+    return plans, expanded_qg
 
 
 def validate_and_annotate_og_list(

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -297,7 +297,7 @@ async def generate_plans(
         qgraph: QueryGraph,
         kp_registry: Registry = None,
         logger: logging.Logger = LOGGER,
-) -> (list[dict[Step, list]], dict[str, dict]):
+) -> list[dict[Step, list]]:
     """
     Given a query graph, build plans that consists of steps
     and the KPs we need to contact to evaluate those steps.

--- a/strider/server.py
+++ b/strider/server.py
@@ -358,7 +358,7 @@ async def generate_traversal_plan(
 ) -> list[dict]:
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
-    plans = await generate_plans(query_graph)
+    plans, _ = await generate_plans(query_graph)
 
     plans_stringified_keys = []
     for plan in plans:

--- a/strider/server.py
+++ b/strider/server.py
@@ -30,6 +30,7 @@ from .storage import RedisGraph, RedisList
 from .config import settings
 from .logging import LogLevelEnum
 from .util import standardize_graph_lists
+from .trapi import expand_qg
 
 LOGGER = logging.getLogger(__name__)
 
@@ -358,7 +359,9 @@ async def generate_traversal_plan(
 ) -> list[dict]:
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
-    plans, _ = await generate_plans(query_graph)
+
+    query_graph = await expand_qg(query_graph, LOGGER)
+    plans = await generate_plans(query_graph)
 
     plans_stringified_keys = []
     for plan in plans:

--- a/strider/worker.py
+++ b/strider/worker.py
@@ -32,10 +32,12 @@ class Worker(ABC):
     def __init__(
             self,
             num_workers: int = 1,
+            logger: logging.Logger = LOGGER,
             **kwargs,
     ):
         """Initialize."""
         self.num_workers = num_workers
+        self.logger = logger
 
         self.queue = asyncio.PriorityQueue()
         self.counter = itertools.count()
@@ -49,11 +51,10 @@ class Worker(ABC):
         try:
             await self.on_message(message)
         except Exception as err:
-            LOGGER.exception(
-                "Aborted processing of %s due to error: %s",
-                message,
-                str(err),
-            )
+            self.logger.exception({
+                "message": "Aborted processing of queue item due to exception",
+                "queue_item": message,
+            })
 
     async def consume(self):
         """Consume messages."""

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -95,7 +95,7 @@ async def test_not_enough_kps(caplog):
         """
     )
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger()
     )
@@ -128,7 +128,7 @@ async def test_no_reverse_edge_in_plan(caplog):
         """
     )
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -167,7 +167,7 @@ async def test_no_path_from_pinned_node(caplog):
     permutations = await find_valid_permutations(operation_graph)
     assert len(list(permutations))
 
-    plans = await generate_plans(
+    plans, _ = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -197,7 +197,7 @@ async def test_solve_reverse_edge(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -232,7 +232,7 @@ async def test_plan_ex1(caplog):
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     plan = plans[0]
     # One step per edge
     assert len(plan.keys()) == len(qg['edges'])
@@ -267,7 +267,7 @@ async def test_invalid_two_pinned_nodes(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -295,7 +295,7 @@ async def test_unbound_unconnected_node(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -324,7 +324,7 @@ async def test_invalid_two_disconnected_components(caplog):
         """
     )
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -361,7 +361,7 @@ async def test_bad_norm(caplog):
         }
     }
 
-    plans = await generate_plans(qg)
+    plans, _ = await generate_plans(qg)
     assert any(
         (
             record.levelname == "WARNING"

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -96,6 +96,7 @@ async def test_not_enough_kps(caplog):
         n0-- biolink:related_to -->n1
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(
         qg,
@@ -129,6 +130,7 @@ async def test_no_reverse_edge_in_plan(caplog):
         n0-- biolink:related_to -->n1
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(
         qg,
@@ -162,6 +164,7 @@ async def test_no_path_from_pinned_node(caplog):
         n1-- biolink:treats -->n0
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     # We should have valid permutations
     expanded_qg = await expand_qg(qg)
@@ -198,6 +201,7 @@ async def test_solve_reverse_edge(caplog):
         n1-- biolink:treats -->n0
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -215,8 +219,8 @@ async def test_valid_permute_ex1(caplog):
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
 
-    expanded_qg = await expand_qg(qg)
-    operation_graph = await qg_to_og(expanded_qg)
+    qg = await expand_qg(qg, logging.getLogger())
+    operation_graph = await qg_to_og(qg)
     plans = await find_valid_permutations(operation_graph)
 
     assert plans
@@ -233,6 +237,7 @@ async def test_plan_ex1(caplog):
     """ Test that we get a good plan for our first example """
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     plan = plans[0]
@@ -268,6 +273,7 @@ async def test_invalid_two_pinned_nodes(caplog):
         n2(( id MONDO:0011122 ))
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -296,6 +302,7 @@ async def test_unbound_unconnected_node(caplog):
         n2(( category biolink:PhenotypicFeature ))
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -325,6 +332,7 @@ async def test_invalid_two_disconnected_components(caplog):
         n2-- biolink:treated_by -->n3
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -362,6 +370,7 @@ async def test_bad_norm(caplog):
             }
         }
     }
+    qg = await expand_qg(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert any(
@@ -395,6 +404,7 @@ async def test_planning_performance_generic_qg():
         n1-- biolink:related_to -->n2
         """
     )
+    qg = await expand_qg(qg, logging.getLogger())
     await time_and_display(
         partial(generate_plans, qg, logger=logging.getLogger()),
         "generate plan for a generic query graph (1000 kps)",
@@ -415,6 +425,7 @@ async def test_planning_performance_typical_example():
 
     with open(cwd / "ex2_qg.json", "r") as f:
         qg = json.load(f)
+    qg = await expand_qg(qg, logging.getLogger())
 
     async def testable_generate_plans():
         await generate_plans(qg, logger=logging.getLogger())

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -17,8 +17,10 @@ from tests.helpers.logger import assert_no_level
 
 
 from strider.query_planner import \
-    generate_plans, find_valid_permutations, permute_og, expand_qg, qg_to_og, \
-    NoAnswersError, qg_to_og
+    generate_plans, find_valid_permutations, \
+    permute_og, qg_to_og, \
+    NoAnswersError
+from strider.trapi import expand_qg
 
 from strider.config import settings
 
@@ -95,7 +97,7 @@ async def test_not_enough_kps(caplog):
         """
     )
 
-    plans, _ = await generate_plans(
+    plans = await generate_plans(
         qg,
         logger=logging.getLogger()
     )
@@ -128,7 +130,7 @@ async def test_no_reverse_edge_in_plan(caplog):
         """
     )
 
-    plans, _ = await generate_plans(
+    plans = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -167,7 +169,7 @@ async def test_no_path_from_pinned_node(caplog):
     permutations = await find_valid_permutations(operation_graph)
     assert len(list(permutations))
 
-    plans, _ = await generate_plans(
+    plans = await generate_plans(
         qg,
         logger=logging.getLogger(),
     )
@@ -197,7 +199,7 @@ async def test_solve_reverse_edge(caplog):
         """
     )
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -232,7 +234,7 @@ async def test_plan_ex1(caplog):
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     plan = plans[0]
     # One step per edge
     assert len(plan.keys()) == len(qg['edges'])
@@ -267,7 +269,7 @@ async def test_invalid_two_pinned_nodes(caplog):
         """
     )
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     assert len(plans) == 1
     assert_no_level(caplog, logging.WARNING)
 
@@ -295,7 +297,7 @@ async def test_unbound_unconnected_node(caplog):
         """
     )
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -324,7 +326,7 @@ async def test_invalid_two_disconnected_components(caplog):
         """
     )
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     assert len(plans) == 0
     assert_no_level(caplog, logging.WARNING, 1)
 
@@ -361,7 +363,7 @@ async def test_bad_norm(caplog):
         }
     }
 
-    plans, _ = await generate_plans(qg)
+    plans = await generate_plans(qg)
     assert any(
         (
             record.levelname == "WARNING"

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -228,7 +228,6 @@ async def test_solve_missing_category():
     normalizer_data="""
         CHEBI:6801 categories biolink:Drug
         """
-
 )
 async def test_normalizer_different_category():
     """

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -217,6 +217,50 @@ async def test_solve_missing_category():
 @with_translator_overlay(
     settings.kpregistry_url,
     settings.normalizer_url,
+    kp_data={
+        "ctd":
+        """
+            CHEBI:6801(( category biolink:Drug ))
+            MONDO:0005148(( category biolink:Disease ))
+            CHEBI:6801-- predicate biolink:treats -->MONDO:0005148
+        """
+    },
+    normalizer_data="""
+        CHEBI:6801 categories biolink:Drug
+        """
+
+)
+async def test_normalizer_different_category():
+    """
+    Test solving a query graph where the category provided doesn't match
+    the one in the node normalizer.
+    """
+
+    QGRAPH = query_graph_from_string(
+        """
+        n0(( category biolink:ChemicalSubstance ))
+        n0(( id CHEBI:6801 ))
+        n1(( category biolink:Disease ))
+        n0-- biolink:treats -->n1
+        """
+    )
+
+    # Create query
+    q = Query(
+        message=Message(
+            query_graph=QueryGraph.parse_obj(QGRAPH)
+        )
+    )
+
+    # Run
+    output = await sync_query(q)
+    assert_no_warnings_trapi(output)
+
+
+@pytest.mark.asyncio
+@with_translator_overlay(
+    settings.kpregistry_url,
+    settings.normalizer_url,
     {
         "ctd":
         """


### PR DESCRIPTION
Fixed #62 where the category given does not match the one that is in the normalizer. The fix involves passing the expanded query graph into StriderWorker and then using that for partial results.