### PR TITLE
Symmetric & Inverse Predicate Handling

### DIFF
--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -157,7 +157,15 @@ def make_og_edge(
         edge_reverse: bool,
         predicate_reverse: bool,
         predicates: list = None,
-):
+) -> dict:
+    """
+    Build an operation graph edge from a query graph.
+
+    Accepts parameters to invert the edge direction (source -> target, target -> source)
+    and the predicate direction (-treats-> or <-treats-).
+
+    Also accepts a custom list of predicates.
+    """
     og_edge = {}
 
     # Annotate operation graph edge
@@ -185,12 +193,13 @@ def make_og_edge(
     return og_edge
 
 
-async def qg_to_og(
-        qgraph,
-        logger: logging.Logger = logging.getLogger(),
-        reverse: bool = True,
-):
-    """Convert query graph to operation graph"""
+async def qg_to_og(qgraph):
+    """
+    Convert query graph to operation graph
+
+    This will add reverse, symmetric,
+    and inverse edges when they are available
+    """
     ograph = {
         "nodes": copy.deepcopy(qgraph["nodes"]),
         "edges": dict(),

--- a/strider/util.py
+++ b/strider/util.py
@@ -81,9 +81,11 @@ class WrappedBMT():
     def predicate_inverse(self, predicate):
         """ Get the inverse of a predicate if it has one """
         predicate_old_format = self.new_case_to_old_case(predicate)
-        return self.old_case_to_new_case(
-            self.bmt.get_element(predicate_old_format).inverse
-        )
+        predicate_inverse_old_format = self.bmt.get_element(
+            predicate_old_format).inverse
+        if predicate_inverse_old_format:
+            return self.old_case_to_new_case(predicate_inverse_old_format)
+        return None
 
 
 async def post_json(url, request):

--- a/strider/util.py
+++ b/strider/util.py
@@ -73,6 +73,18 @@ class WrappedBMT():
             ancestors.append(concept)
         return ancestors
 
+    def predicate_is_symmetric(self, predicate):
+        """ Get whether a given predicate is symmetric """
+        predicate_old_format = self.new_case_to_old_case(predicate)
+        return self.bmt.get_element(predicate_old_format).symmetric
+
+    def predicate_inverse(self, predicate):
+        """ Get the inverse of a predicate if it has one """
+        predicate_old_format = self.new_case_to_old_case(predicate)
+        return self.old_case_to_new_case(
+            self.bmt.get_element(predicate_old_format).inverse
+        )
+
 
 async def post_json(url, request):
     """Make post request."""

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -69,10 +69,10 @@ async def test_permute_simple(caplog):
     permutations = permute_graph(operation_graph)
     assert permutations
 
-    # We should have:
-    # 4 * 2 * 3 = 24
-    # permutations
-    assert len(list(permutations)) == 24
+    # We should have 4 * 2 * 3 * 3 = 72
+    # permutations because three of our predicates
+    # have inverses as well
+    assert len(list(permutations)) == 72
     assert_no_level(caplog, logging.WARNING)
 
 

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -65,7 +65,7 @@ async def test_permute_simple(caplog):
     )
 
     qg = await expand_qg(qg, logging.getLogger())
-    operation_graph = await qg_to_og(qg, reverse=False)
+    operation_graph = await qg_to_og(qg)
     permutations = permute_graph(operation_graph)
     assert permutations
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -630,10 +630,6 @@ async def test_mutability_bug():
             CHEBI:6801-- predicate biolink:treats -->MONDO:0005148
         """
     },
-    normalizer_data="""
-        CHEBI:6801 categories biolink:Drug
-        MONDO:0005148 categories biolink:Disease
-        """
 )
 async def test_inverse_predicate():
     """
@@ -658,7 +654,7 @@ async def test_inverse_predicate():
     )
 
     # Run
-    output = await sync_query(q)
+    output = await sync_query(q, log_level='DEBUG')
     assert_no_warnings_trapi(output)
 
 


### PR DESCRIPTION
Updated query planning to handle symmetric and inverse predicates. This involved removing the `operation_kp_map` object and instead using the operation graph to hold KP information. 

Right now because BMT is not updated the symmetric predicate test will fail. To force the test to pass, you can add the following code to the `WrappedBMT.predicate_is_symmetric` method:
```python
if predicate_old_format == "correlated_with":
    return True
```