### PR TITLE
Descendant Reverse Fix

### DIFF
--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -203,6 +203,7 @@ class StriderWorker(Worker):
             )
             for kp in self.plan[step]
             if kp["source_category"] in category
+            or kp["target_category"] in category
         ))
         return merge_messages(responses)
 

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -21,7 +21,8 @@ from reasoner_pydantic import QueryGraph, Result, Response
 
 from .query_planner import generate_plans, Step, NoAnswersError
 from .compatibility import KnowledgePortal
-from .trapi import merge_messages, merge_results, expand_qg
+from .trapi import merge_messages, merge_results, \
+    fill_categories_predicates, add_descendants
 from .worker import Worker
 from .caching import async_locking_cache
 from .storage import RedisGraph, RedisList, RedisLogHandler
@@ -121,7 +122,8 @@ class StriderWorker(Worker):
         ))["query_graph"]
 
         # Expand the query graph using the biolink model hierarchies
-        self.qgraph = await expand_qg(self.qgraph, self.logger)
+        await fill_categories_predicates(self.qgraph, self.logger)
+        await add_descendants(self.qgraph, self.logger)
 
     async def generate_plan(self):
         """

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -22,13 +22,13 @@ from reasoner_pydantic import QueryGraph, Result, Response
 from .query_planner import generate_plans, Step, NoAnswersError
 from .compatibility import KnowledgePortal
 from .trapi import merge_messages, merge_results, \
-    fill_categories_predicates, add_descendants
+    fill_categories_predicates
 from .worker import Worker
 from .caching import async_locking_cache
 from .storage import RedisGraph, RedisList, RedisLogHandler
 from .kp_registry import Registry
 from .config import settings
-from .util import ensure_list
+from .util import ensure_list, standardize_graph_lists
 
 # Initialize registry
 registry = Registry(settings.kpregistry_url)
@@ -123,7 +123,7 @@ class StriderWorker(Worker):
 
         # Expand the query graph using the biolink model hierarchies
         await fill_categories_predicates(self.qgraph, self.logger)
-        await add_descendants(self.qgraph, self.logger)
+        standardize_graph_lists(self.qgraph)
 
     async def generate_plan(self):
         """

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -482,14 +482,11 @@ async def generate_plans(
                 else:
                     step = Step(edge['subject'], edge_id, edge['object'])
 
-                forward_kps = get_query_graph_edge_kps(
-                    current_og, edge_id, False)
-                reverse_kps = get_query_graph_edge_kps(
-                    current_og, edge_id, True)
+                kps = get_query_graph_edge_kps(
+                    current_og, edge_id, reverse)
 
                 # Attach information about categorys to kp info
-                all_kps = {**forward_kps, **reverse_kps}
-                for kp_name, kp in all_kps.items():
+                for kp_name, kp in kps.items():
                     kp_without_ops = {x: kp[x]
                                       for x in kp if x != 'operations'}
                     kp_without_ops['name'] = kp_name

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -1,9 +1,8 @@
 """Query planner."""
-from collections import defaultdict, namedtuple, ChainMap
+from collections import defaultdict, namedtuple
 import logging
 import copy
-from typing import Generator, Callable
-import re
+from typing import Generator
 
 from reasoner_pydantic import QueryGraph
 
@@ -347,6 +346,9 @@ def ensure_traversal_connected(graph, path):
     return pinned_nodes | path_nodes == graph_nodes
 
 
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
 async def generate_plans(
         qgraph: QueryGraph,
         kp_registry: Registry = None,

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -1,5 +1,5 @@
 """Query planner."""
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, ChainMap
 import logging
 import copy
 from typing import Generator, Callable
@@ -10,6 +10,7 @@ from reasoner_pydantic import QueryGraph
 from strider.kp_registry import Registry
 from strider.util import WrappedBMT
 from strider.config import settings
+from strider.trapi import add_descendants
 
 LOGGER = logging.getLogger(__name__)
 
@@ -121,9 +122,8 @@ async def annotate_operation_graph(
         kp_registry: Registry = None,
 ):
     """
-    Look up kps for each operation in a query graph
-
-    Put the results in a master dictionary
+    Look up kps for each edge in an operation graph
+    and add it to the "kps" property of the edge
     """
     if kp_registry is None:
         kp_registry = Registry(settings.kpregistry_url)
@@ -262,58 +262,43 @@ async def qg_to_og(qgraph):
     return ograph
 
 
-async def filter_categories_predicates(query_graph, operation_graph):
-    """Filter out categories and predicates that cannot be found using KPs."""
-    for node in query_graph['nodes'].values():
+def filter_categories_predicates(operation_graph):
+    """
+    Filter out categories and predicates that are not defined in any KP
+    """
+    for node in operation_graph['nodes'].values():
         node['filtered_categories'] = set()
-    for edge in query_graph['edges'].values():
+    for edge in operation_graph['edges'].values():
         edge['filtered_predicates'] = set()
 
-    for qg_edge_id, edge in query_graph['edges'].items():
+    for edge in operation_graph['edges'].values():
+        for kp in edge["kps"].values():
+            for kp_operation in kp["operations"]:
+                source_node = operation_graph["nodes"][edge["source"]]
+                target_node = operation_graph["nodes"][edge["target"]]
 
-        associated_operation_graph_edges = [
-            edge for edge in operation_graph["edges"].values()
-            if edge["qg_edge_id"] == qg_edge_id
-        ]
-
-        sub = query_graph['nodes'][edge['subject']]
-        obj = query_graph['nodes'][edge['object']]
-
-        for og_edge in associated_operation_graph_edges:
-
-            for kp in og_edge["kps"].values():
-                for kp_operation in kp["operations"]:
-                    if og_edge["qg_traversal_reverse"]:
-                        source = obj
-                        target = sub
-                    else:
-                        source = sub
-                        target = obj
-
-                    source['filtered_categories'].add(
-                        kp_operation["source_category"])
-                    target['filtered_categories'].add(
-                        kp_operation["target_category"])
-                    # Remove arrows
-                    edge['filtered_predicates'].add(
-                        re.sub(r"[<\->]", "", kp_operation["edge_predicate"])
-                    )
+                source_node['filtered_categories'].add(
+                    kp_operation["source_category"])
+                target_node['filtered_categories'].add(
+                    kp_operation["target_category"])
+                edge['filtered_predicates'].add(
+                    kp_operation["edge_predicate"]
+                )
 
     # We only filter nodes that are touching at least one edge ("connected")
     connected_nodes = set()
-    for edge in query_graph['edges'].values():
-        connected_nodes.add(edge['subject'])
-        connected_nodes.add(edge['object'])
+    for edge in operation_graph['edges'].values():
+        connected_nodes.add(edge['source'])
+        connected_nodes.add(edge['target'])
     for node_id in connected_nodes:
-        node = query_graph['nodes'][node_id]
+        node = operation_graph['nodes'][node_id]
         if 'category' not in node:
             continue
         node['category'] = list(node.pop('filtered_categories'))
 
     # Also filter edge predicates as well
-    for edge in query_graph['edges'].values():
+    for edge in operation_graph['edges'].values():
         edge['predicate'] = list(edge.pop('filtered_predicates'))
-    return None
 
 
 def get_next_nodes(
@@ -403,6 +388,8 @@ async def generate_plans(
 
     operation_graph = await qg_to_og(qgraph)
 
+    add_descendants(operation_graph, logger)
+
     await annotate_operation_graph(operation_graph, kp_registry)
 
     logger.debug({
@@ -413,17 +400,14 @@ async def generate_plans(
     # Filter down node categories using those
     # we have recieved from the KP registry
     # to limit the number of permutations.
-    await filter_categories_predicates(qgraph, operation_graph)
+    filter_categories_predicates(operation_graph)
 
     logger.debug({
         "message": "Filtered query graph based on operations",
         "filtered_qgraph": qgraph,
     })
 
-    query_graph_permutations = permute_graph(qgraph)
-
-    annotated_query_graph_permutations = \
-        annotate_query_graph_list(query_graph_permutations, operation_graph)
+    operation_graph_permutations = permute_graph(operation_graph)
 
     # Build a list of pinned nodes
     pinned_nodes = [
@@ -440,25 +424,28 @@ async def generate_plans(
 
     logger.info("Searching query graph permutations for plans")
 
-    for current_qg in annotated_query_graph_permutations:
+    for current_og in operation_graph_permutations:
+        filter_operation_graph_kps(current_og)
 
         # Create a graph where all nodes and edges
         # from the operation graph are nodes ("reified")
         #
         # This graph is stored as an adjacency list
         reified_graph = {}
-        for node_id in current_qg['nodes'].keys():
+        for node_id in qgraph['nodes'].keys():
             reified_graph[node_id] = []
-        for edge_id in current_qg['edges'].keys():
+        for edge_id in qgraph['edges'].keys():
             reified_graph[edge_id] = []
 
         # Fill in adjacencies
-        for edge_id, edge in current_qg['edges'].items():
-            if len(edge['forward_kps']) > 0:
+        for edge_id, edge in qgraph['edges'].items():
+            forward_kps = get_query_graph_edge_kps(current_og, edge_id, False)
+            if len(forward_kps) > 0:
                 # Adjacency for forward edge
                 reified_graph[edge['subject']].append(edge_id)
                 reified_graph[edge_id].append(edge['object'])
-            if len(edge['reverse_kps']) > 0:
+            reverse_kps = get_query_graph_edge_kps(current_og, edge_id, True)
+            if len(reverse_kps) > 0:
                 # Adjacency for reverse edge
                 reified_graph[edge['object']].append(edge_id)
                 reified_graph[edge_id].append(edge['subject'])
@@ -472,7 +459,7 @@ async def generate_plans(
             )
 
         possible_traversals = filter(
-            lambda t: ensure_traversal_connected(current_qg, t),
+            lambda t: ensure_traversal_connected(qgraph, t),
             possible_traversals)
 
         for traversal in possible_traversals:
@@ -480,13 +467,13 @@ async def generate_plans(
             plan = defaultdict(list)
             for index, edge_id in enumerate(traversal):
                 # Skip iteration for non-edges
-                if edge_id not in current_qg['edges'].keys():
+                if edge_id not in qgraph['edges'].keys():
                     continue
 
                 # We need to know which way to step through the edge
                 # so we use the previous value in the traversal
                 # which is always the source node
-                edge = current_qg['edges'][edge_id]
+                edge = qgraph['edges'][edge_id]
                 source_node_id = traversal[index - 1]
                 reverse = source_node_id == edge['object']
 
@@ -494,10 +481,15 @@ async def generate_plans(
                     step = Step(edge['object'], edge_id, edge['subject'])
                 else:
                     step = Step(edge['subject'], edge_id, edge['object'])
-                op = get_operation(current_qg, edge, reverse=reverse)
+                op = get_operation(qgraph, edge, reverse=reverse)
+
+                forward_kps = get_query_graph_edge_kps(
+                    current_og, edge_id, False)
+                reverse_kps = get_query_graph_edge_kps(
+                    current_og, edge_id, True)
 
                 # Attach information about categorys to kp info
-                all_kps = {**edge['forward_kps'], **edge['reverse_kps']}
+                all_kps = {**forward_kps, **reverse_kps}
                 for kp_name, kp in all_kps.items():
                     kp_without_ops = {x: kp[x]
                                       for x in kp if x != 'operations'}
@@ -533,6 +525,25 @@ async def generate_plans(
         })
 
     return plans
+
+
+def filter_operation_graph_kps(
+    operation_graph: dict[str, dict],
+):
+    """
+    Remove KPs that don't match the operation graph's
+    node categories or edge predicates.
+    """
+    for edge in operation_graph["edges"].values():
+        edge_operation = {
+            "edge_predicate": edge["predicate"],
+            "source_category": operation_graph["nodes"][edge["source"]]["category"],
+            "target_category": operation_graph["nodes"][edge["target"]]["category"],
+        }
+        edge["kps"] = {name: kp
+                       for name, kp in edge["kps"].items()
+                       if edge_operation in kp["operations"]
+                       }
 
 
 def annotate_query_graph(
@@ -575,6 +586,34 @@ def annotate_query_graph_list(
         valid = annotate_query_graph(qg, operation_graph)
         if valid:
             yield qg
+
+
+def get_query_graph_edge_kps(
+    operation_graph: dict[str, dict],
+    qg_edge_id: str,
+    reverse: bool,
+) -> dict[str, dict]:
+    """
+    Get KPs from the operation graph that
+    correspond to a query graph edge
+    """
+    kps = {}
+
+    for og_edge in operation_graph["edges"].values():
+        if og_edge["qg_edge_id"] != qg_edge_id:
+            continue
+        if og_edge["qg_traversal_reverse"] != reverse:
+            continue
+
+        for current_kp_name, current_kp in og_edge["kps"].items():
+            # Add information to KPs about operation graph edge
+            kps[current_kp_name] = {
+                **current_kp,
+                "source_category": operation_graph["nodes"][og_edge["source"]]["category"],
+                "edge_predicate": og_edge["predicate"],
+                "target_category": operation_graph["nodes"][og_edge["target"]]["category"],
+            }
+    return kps
 
 
 # pylint: disable=too-many-arguments

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -96,27 +96,6 @@ class NoAnswersError(Exception):
     """No answers can be found."""
 
 
-def get_operation(
-        query_graph: dict,
-        edge: dict,
-        reverse: bool = False,
-) -> Operation:
-    """ Get the types from an edge in the query graph """
-
-    if reverse:
-        return Operation(
-            query_graph['nodes'][edge['object']]['category'],
-            f"<-{edge['predicate']}-",
-            query_graph['nodes'][edge['subject']]['category'],
-        )
-    else:
-        return Operation(
-            query_graph['nodes'][edge['subject']]['category'],
-            f"-{edge['predicate']}->",
-            query_graph['nodes'][edge['object']]['category'],
-        )
-
-
 async def annotate_operation_graph(
         operation_graph: dict[str, dict],
         kp_registry: Registry = None,

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -481,7 +481,6 @@ async def generate_plans(
                     step = Step(edge['object'], edge_id, edge['subject'])
                 else:
                     step = Step(edge['subject'], edge_id, edge['object'])
-                op = get_operation(qgraph, edge, reverse=reverse)
 
                 forward_kps = get_query_graph_edge_kps(
                     current_og, edge_id, False)
@@ -495,10 +494,7 @@ async def generate_plans(
                                       for x in kp if x != 'operations'}
                     kp_without_ops['name'] = kp_name
 
-                    plan[step].append({
-                        **op._asdict(),
-                        **kp_without_ops,
-                    })
+                    plan[step].append(kp_without_ops)
             plans.append(plan)
 
     num_duplicated_plans = len(plans)

--- a/strider/server.py
+++ b/strider/server.py
@@ -361,7 +361,7 @@ async def generate_traversal_plan(
     query_graph = query.message.query_graph.dict()
 
     await fill_categories_predicates(query_graph, logging.getLogger())
-    await add_descendants(query_graph, logging.getLogger())
+    standardize_graph_lists(query_graph)
     plans = await generate_plans(query_graph)
 
     plans_stringified_keys = []

--- a/strider/server.py
+++ b/strider/server.py
@@ -30,7 +30,7 @@ from .storage import RedisGraph, RedisList
 from .config import settings
 from .logging import LogLevelEnum
 from .util import standardize_graph_lists
-from .trapi import expand_qg
+from .trapi import fill_categories_predicates, add_descendants
 
 LOGGER = logging.getLogger(__name__)
 
@@ -360,7 +360,8 @@ async def generate_traversal_plan(
     """Generate plans for traversing knowledge providers."""
     query_graph = query.message.query_graph.dict()
 
-    query_graph = await expand_qg(query_graph, LOGGER)
+    await fill_categories_predicates(query_graph, logging.getLogger())
+    await add_descendants(query_graph, logging.getLogger())
     plans = await generate_plans(query_graph)
 
     plans_stringified_keys = []

--- a/strider/trapi.py
+++ b/strider/trapi.py
@@ -1,7 +1,5 @@
 """TRAPI utilities."""
 from collections import defaultdict
-from collections.abc import Callable
-import copy
 import logging
 
 from reasoner_pydantic import Message, Result, QNode, Node, Edge

--- a/strider/util.py
+++ b/strider/util.py
@@ -16,7 +16,7 @@ def snake_to_camel(s):
 
 
 class WrappedBMT():
-    """ 
+    """
     Wrapping around some of the BMT Toolkit functions
     to provide case conversions to the new format
     """
@@ -136,6 +136,22 @@ def standardize_graph_lists(graph: dict[str, dict]):
     for edge in graph['edges'].values():
         for field in edge_fields:
             listify_value(edge, field)
+
+
+def extract_predicate_direction(predicate: str) -> tuple[str, bool]:
+    """ Extract predicate direction from string with enclosing arrows """
+    if "<-" in predicate:
+        return predicate[2:-1], True
+    else:
+        return predicate[1:-2], False
+
+
+def build_predicate_direction(predicate: str, reverse: bool) -> str:
+    """ Given a tuple of predicate string and direction, build a string with arrows """
+    if reverse:
+        return f"<-{predicate}-"
+    else:
+        return f"-{predicate}->"
 
 
 def message_to_list_form(message):

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -1,13 +1,9 @@
 from pathlib import Path
 from functools import partial
-import os
-import math
 import json
 import logging
-import random
 
 import pytest
-from bmt import Toolkit as BMToolkit
 
 from tests.helpers.context import \
     with_registry_overlay, with_norm_overlay
@@ -18,7 +14,7 @@ from tests.helpers.logger import assert_no_level
 
 from strider.query_planner import \
     permute_graph, qg_to_og, \
-    generate_plans, NoAnswersError, add_descendants
+    generate_plans, add_descendants
 
 from strider.trapi import fill_categories_predicates
 
@@ -218,7 +214,7 @@ async def test_solve_reverse_edge(caplog):
     """
 ))
 @with_norm_overlay(settings.normalizer_url)
-async def test_plan_loop(caplog):
+async def test_plan_loop():
     """
     Test that we create a plan for a query with a loop
     """
@@ -252,7 +248,7 @@ async def test_plan_loop(caplog):
     """
 ))
 @with_norm_overlay(settings.normalizer_url)
-async def test_plan_reuse_pinned(caplog):
+async def test_plan_reuse_pinned():
     """
     Test that we create a plan that uses a pinned node twice
     """

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -20,9 +20,10 @@ from strider.query_planner import \
     permute_graph, qg_to_og, \
     generate_plans, NoAnswersError
 
-from strider.trapi import fill_categories_predicates, add_descendants
+from strider.trapi import fill_categories_predicates
 
 from strider.config import settings
+from strider.util import standardize_graph_lists
 
 cwd = Path(__file__).parent
 
@@ -65,7 +66,7 @@ async def test_permute_simple(caplog):
     )
 
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
     operation_graph = await qg_to_og(qg)
     permutations = permute_graph(operation_graph)
     assert permutations
@@ -98,7 +99,7 @@ async def test_not_enough_kps(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(
         qg,
@@ -133,7 +134,7 @@ async def test_no_reverse_edge_in_plan(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(
         qg,
@@ -168,7 +169,7 @@ async def test_no_path_from_pinned_node(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(
         qg,
@@ -200,7 +201,7 @@ async def test_solve_reverse_edge(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -233,7 +234,7 @@ async def test_plan_loop(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
 
@@ -269,7 +270,7 @@ async def test_plan_reuse_pinned(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
 
@@ -306,7 +307,7 @@ async def test_plan_double_loop(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 8
@@ -324,7 +325,7 @@ async def test_plan_ex1(caplog):
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     plan = plans[0]
@@ -361,7 +362,7 @@ async def test_valid_two_pinned_nodes(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -394,7 +395,7 @@ async def test_fork(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 2
@@ -424,7 +425,7 @@ async def test_unbound_unconnected_node(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -455,7 +456,7 @@ async def test_invalid_two_disconnected_components(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -494,7 +495,7 @@ async def test_bad_norm(caplog):
         }
     }
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     plans = await generate_plans(qg)
     assert any(
@@ -528,7 +529,7 @@ async def test_descendant_reverse_category(caplog):
         """
     )
     await fill_categories_predicates(invalid_qg, logging.getLogger())
-    await add_descendants(invalid_qg, logging.getLogger())
+    standardize_graph_lists(invalid_qg)
     plans = await generate_plans(invalid_qg)
     assert len(plans) == 0
 
@@ -540,7 +541,7 @@ async def test_descendant_reverse_category(caplog):
         """
     )
     await fill_categories_predicates(valid_qg, logging.getLogger())
-    await add_descendants(valid_qg, logging.getLogger())
+    standardize_graph_lists(valid_qg)
     plans = await generate_plans(valid_qg)
     assert len(plans) == 1
 
@@ -568,7 +569,7 @@ async def test_planning_performance_generic_qg():
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
     await time_and_display(
         partial(generate_plans, qg, logger=logging.getLogger()),
         "generate plan for a generic query graph (1000 kps)",
@@ -590,7 +591,7 @@ async def test_planning_performance_typical_example():
     with open(cwd / "ex2_qg.json", "r") as f:
         qg = json.load(f)
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
 
     async def testable_generate_plans():
         await generate_plans(qg, logger=logging.getLogger())
@@ -623,7 +624,7 @@ async def test_double_sided(caplog):
         """
     )
     await fill_categories_predicates(qg, logging.getLogger())
-    await add_descendants(qg, logging.getLogger())
+    standardize_graph_lists(qg)
     plans = await generate_plans(qg, logger=logging.getLogger())
     assert len(plans) == 1
     assert len(list(plans[0].values())[0]) == 1

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -20,7 +20,7 @@ from strider.query_planner import \
     permute_graph, qg_to_og, \
     generate_plans, NoAnswersError
 
-from strider.trapi import expand_qg
+from strider.trapi import fill_categories_predicates, add_descendants
 
 from strider.config import settings
 
@@ -64,7 +64,8 @@ async def test_permute_simple(caplog):
         """
     )
 
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
     operation_graph = await qg_to_og(qg)
     permutations = permute_graph(operation_graph)
     assert permutations
@@ -96,7 +97,8 @@ async def test_not_enough_kps(caplog):
         n0-- biolink:related_to -->n1
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(
         qg,
@@ -130,7 +132,8 @@ async def test_no_reverse_edge_in_plan(caplog):
         n0-- biolink:related_to -->n1
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(
         qg,
@@ -164,7 +167,8 @@ async def test_no_path_from_pinned_node(caplog):
         n1-- biolink:treats -->n0
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(
         qg,
@@ -195,7 +199,8 @@ async def test_solve_reverse_edge(caplog):
         n1-- biolink:treats -->n0
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -227,7 +232,8 @@ async def test_plan_loop(caplog):
         n2-- biolink:treats -->n1
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
 
@@ -262,7 +268,8 @@ async def test_plan_reuse_pinned(caplog):
         n0-- biolink:related_to -->n3
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
 
@@ -298,7 +305,8 @@ async def test_plan_double_loop(caplog):
         n4-- biolink:related_to -->n2
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 8
@@ -315,7 +323,8 @@ async def test_plan_ex1(caplog):
     """ Test that we get a good plan for our first example """
     with open(cwd / "ex1_qg.json", "r") as f:
         qg = json.load(f)
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     plan = plans[0]
@@ -351,7 +360,8 @@ async def test_valid_two_pinned_nodes(caplog):
         n2(( id MONDO:0011122 ))
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 1
@@ -383,7 +393,8 @@ async def test_fork(caplog):
         n0-- biolink:has_phenotype -->n2
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 2
@@ -412,7 +423,8 @@ async def test_unbound_unconnected_node(caplog):
         n2(( category biolink:PhenotypicFeature ))
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -442,7 +454,8 @@ async def test_invalid_two_disconnected_components(caplog):
         n2-- biolink:treated_by -->n3
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert len(plans) == 0
@@ -480,7 +493,8 @@ async def test_bad_norm(caplog):
             }
         }
     }
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     plans = await generate_plans(qg)
     assert any(
@@ -513,7 +527,8 @@ async def test_descendant_reverse_category(caplog):
         n1(( category biolink:Drug ))
         """
     )
-    invalid_qg = await expand_qg(invalid_qg, logging.getLogger())
+    await fill_categories_predicates(invalid_qg, logging.getLogger())
+    await add_descendants(invalid_qg, logging.getLogger())
     plans = await generate_plans(invalid_qg)
     assert len(plans) == 0
 
@@ -524,7 +539,8 @@ async def test_descendant_reverse_category(caplog):
         n1(( category biolink:Drug ))
         """
     )
-    valid_qg = await expand_qg(valid_qg, logging.getLogger())
+    await fill_categories_predicates(valid_qg, logging.getLogger())
+    await add_descendants(valid_qg, logging.getLogger())
     plans = await generate_plans(valid_qg)
     assert len(plans) == 1
 
@@ -551,7 +567,8 @@ async def test_planning_performance_generic_qg():
         n1-- biolink:related_to -->n2
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
     await time_and_display(
         partial(generate_plans, qg, logger=logging.getLogger()),
         "generate plan for a generic query graph (1000 kps)",
@@ -572,7 +589,8 @@ async def test_planning_performance_typical_example():
 
     with open(cwd / "ex2_qg.json", "r") as f:
         qg = json.load(f)
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
 
     async def testable_generate_plans():
         await generate_plans(qg, logger=logging.getLogger())
@@ -604,7 +622,8 @@ async def test_double_sided(caplog):
         n0-- biolink:treated_by -->n1
         """
     )
-    qg = await expand_qg(qg, logging.getLogger())
+    await fill_categories_predicates(qg, logging.getLogger())
+    await add_descendants(qg, logging.getLogger())
     plans = await generate_plans(qg, logger=logging.getLogger())
     assert len(plans) == 1
     assert len(list(plans[0].values())[0]) == 1

--- a/tests/query_planner/test_query_planner.py
+++ b/tests/query_planner/test_query_planner.py
@@ -18,7 +18,7 @@ from tests.helpers.logger import assert_no_level
 
 from strider.query_planner import \
     permute_graph, qg_to_og, \
-    generate_plans, NoAnswersError
+    generate_plans, NoAnswersError, add_descendants
 
 from strider.trapi import fill_categories_predicates
 
@@ -68,6 +68,7 @@ async def test_permute_simple(caplog):
     await fill_categories_predicates(qg, logging.getLogger())
     standardize_graph_lists(qg)
     operation_graph = await qg_to_og(qg)
+    add_descendants(operation_graph)
     permutations = permute_graph(operation_graph)
     assert permutations
 


### PR DESCRIPTION
Added a test for a case where the query graph includes related_to and we need to subclass related_to in both forward and reverse directions. Implemented this change by switching query graph permutations to operation graph permutations. 