### PR TITLE
Switched all->any for knode category validation

### DIFF
--- a/strider/trapi.py
+++ b/strider/trapi.py
@@ -416,9 +416,9 @@ def is_valid_node_binding(message, nb, qgraph_node):
                 WBMT.get_descendants(c)
             )
 
-        # Check that all categories on this
-        # kgraph node are allowed
-        if not all(
+        # Check that at least one of the categories
+        # on this kgraph node is allowed
+        if not any(
             c in qgraph_allowable_categories
             for c in kgraph_node["category"]
         ):


### PR DESCRIPTION
Some KPs return category lists like this for KNodes: 
```
["biolink:NamedThing", "biolink:MolecularEntity"..."biolink:Disease"]
```

So we have to validate any of these categories against the QNode rather than all. Fixes #78.