### PR TITLE
Convert Redis client to FastAPI dependency

### DIFF
--- a/strider/storage.py
+++ b/strider/storage.py
@@ -6,12 +6,11 @@ import logging
 from typing import Optional
 
 import redis
-from redis import Redis
 
 from .config import settings
 
 
-def get_client() -> Redis:
+def get_client() -> redis.Redis:
     """Create a Redis client."""
     return redis.from_url(
         settings.redis_url,
@@ -28,7 +27,7 @@ def mapd(f, d):
 class RedisValue(ABC):
     """Redis value."""
 
-    def __init__(self, key: str, client: Optional[Redis] = None):
+    def __init__(self, key: str, client: Optional[redis.Redis] = None):
         self.client = client or get_client()
         self.key = key
 
@@ -84,7 +83,7 @@ class RedisList(RedisValue):
 class RedisGraph():
     """Redis graph."""
 
-    def __init__(self, key: str, client: Optional[Redis] = None):
+    def __init__(self, key: str, client: Optional[redis.Redis] = None):
         self.nodes = RedisHash(key + ':nodes', client)
         self.edges = RedisHash(key + ':edges', client)
 
@@ -106,7 +105,7 @@ class RedisGraph():
 class RedisLogHandler(logging.Handler):
     """Redis log handler."""
 
-    def __init__(self, key: str, client: Optional[Redis] = None, **kwargs):
+    def __init__(self, key: str, client: Optional[redis.Redis] = None, **kwargs):
         self.store = RedisList(key, client)
         super().__init__(**kwargs)
 

--- a/strider/storage.py
+++ b/strider/storage.py
@@ -3,18 +3,17 @@ from abc import ABC
 import os
 import json
 import logging
+from typing import Optional
+
+import redis
+from redis import Redis
 
 from .config import settings
 
-if settings.redis_url == "redis://fakeredis:6379/0":
-    import fakeredis
-    r = fakeredis.FakeRedis(
-        encoding="utf-8",
-        decode_responses=True,
-    )
-else:
-    import redis
-    r = redis.from_url(
+
+def get_client() -> Redis:
+    """Create a Redis client."""
+    return redis.from_url(
         settings.redis_url,
         encoding="utf-8",
         decode_responses=True,
@@ -29,37 +28,38 @@ def mapd(f, d):
 class RedisValue(ABC):
     """Redis value."""
 
-    def __init__(self, key: str):
+    def __init__(self, key: str, client: Optional[Redis] = None):
+        self.client = client or get_client()
         self.key = key
 
     def expire(self, when: int):
-        r.expire(self.key, when)
+        self.client.expire(self.key, when)
 
 
 class RedisHash(RedisValue):
     """Redis hash."""
 
     def get(self):
-        v = r.hgetall(self.key)
+        v = self.client.hgetall(self.key)
         return mapd(json.loads, v)
 
     def set(self, v: dict):
-        r.delete(self.key)
+        self.client.delete(self.key)
         if not len(v):
             return
-        r.hset(
+        self.client.hset(
             self.key,
             mapping=mapd(json.dumps, v)
         )
 
     def get_val(self):
-        v = r.hget(self.key)
+        v = self.client.hget(self.key)
         return json.load(v)
 
     def merge(self, v: dict):
         if not len(v):
             return
-        r.hset(
+        self.client.hset(
             self.key,
             mapping=mapd(json.dumps, v)
         )
@@ -69,24 +69,24 @@ class RedisList(RedisValue):
     """Redis list."""
 
     def get(self):
-        v = r.lrange(self.key, 0, -1)
+        v = self.client.lrange(self.key, 0, -1)
         return map(json.loads, v)
 
     def set(self, v: list[any]):
         # Clear
-        r.delete(self.key)
-        r.push(**map(json.dumps, v))
+        self.client.delete(self.key)
+        self.client.push(**map(json.dumps, v))
 
     def append(self, v):
-        r.lpush(self.key, json.dumps(v))
+        self.client.lpush(self.key, json.dumps(v))
 
 
 class RedisGraph():
     """Redis graph."""
 
-    def __init__(self, key: str):
-        self.nodes = RedisHash(key + ':nodes')
-        self.edges = RedisHash(key + ':edges')
+    def __init__(self, key: str, client: Optional[Redis] = None):
+        self.nodes = RedisHash(key + ':nodes', client)
+        self.edges = RedisHash(key + ':edges', client)
 
     def expire(self, when: int):
         self.nodes.expire(when)
@@ -106,9 +106,9 @@ class RedisGraph():
 class RedisLogHandler(logging.Handler):
     """Redis log handler."""
 
-    def __init__(self, key: str, *args, **kwargs):
-        self.store = RedisList(key)
-        super().__init__(*args, **kwargs)
+    def __init__(self, key: str, client: Optional[Redis] = None, **kwargs):
+        self.store = RedisList(key, client)
+        super().__init__(**kwargs)
 
     def emit(self, record):
         log_entry = self.format(record)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 
+import fakeredis
 from fastapi.responses import Response
 import httpx
 import pytest
@@ -14,14 +15,17 @@ from tests.helpers.logger import setup_logger
 from tests.helpers.utils import query_graph_from_string, validate_message
 
 from strider.config import settings
+from strider.server import APP
+from strider.storage import get_client
 
 # Switch prefix path before importing server
 settings.kpregistry_url = "http://registry"
 settings.normalizer_url = "http://normalizer"
-settings.redis_url = "redis://fakeredis:6379/0"
 
-from strider.server import APP
-
+APP.dependency_overrides[get_client] = lambda: fakeredis.FakeRedis(
+    encoding="utf-8",
+    decode_responses=True,
+)
 client = httpx.AsyncClient(app=APP, base_url="http://test")
 
 setup_logger()


### PR DESCRIPTION
This has a few benefits:
* Redis connections are tied to requests
* We don't need the configuration hack during testing
* We may be able to remove the Redis URL configuration entirely

and one drawback:
* We have to pass the client around everywhere