### PR TITLE
v2.0.4

### DIFF
--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -86,6 +86,13 @@ class KnowledgePortal():
             response['message']['results'] = []
 
         message = response["message"]
+        if message.get("query_graph") is None:
+            message = {
+                "query_graph": request["message"]["query_graph"],
+                "knowledge_graph": {"nodes": {}, "edges": {}},
+                "results": [],
+            }
+
         message = await self.map_prefixes(message, output_prefixes)
 
         add_source(message, url)

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -58,7 +58,7 @@ class KnowledgePortal():
         request['message'] = await self.map_prefixes(request['message'], input_prefixes)
         request = remove_null_values(request)
 
-        trapi_request = Query.parse_obj(request).dict(by_alias=True)
+        trapi_request = Query.parse_obj(request).dict(by_alias=True, exclude_unset=True)
         try:
             response = await post_json(
                 url, trapi_request, self.logger, "KP"

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -65,10 +65,13 @@ class KnowledgePortal():
             )
         except StriderRequestError:
             # Continue processing with an empty response object
-            response = {"message" : {}}
-            response['message']['query_graph'] = request['message']['query_graph']
-            response['message']['knowledge_graph'] = {'nodes': {}, 'edges': {}}
-            response['message']['results'] = []
+            response = {
+                "message" : {
+                    "query_graph": request["message"]["query_graph"],
+                    "knowledge_graph": {"nodes": {}, "edges": {}},
+                    "results": [],
+                }
+            }
 
         try:
             # Parse with reasoner_pydantic to validate
@@ -80,10 +83,13 @@ class KnowledgePortal():
                 "error": str(e),
             })
             # Continue processing with an empty response object
-            response = {"message" : {}}
-            response['message']['query_graph'] = request['message']['query_graph']
-            response['message']['knowledge_graph'] = {'nodes': {}, 'edges': {}}
-            response['message']['results'] = []
+            response = {
+                "message" : {
+                    "query_graph": request["message"]["query_graph"],
+                    "knowledge_graph": {"nodes": {}, "edges": {}},
+                    "results": [],
+                }
+            }
 
         message = response["message"]
         if message.get("query_graph") is None:

--- a/strider/config.py
+++ b/strider/config.py
@@ -7,7 +7,7 @@ from pydantic import \
 
 class Settings(BaseSettings):
     openapi_server_url: Optional[AnyUrl]
-    kpregistry_url: AnyUrl = "http://kp-registry.renci.org"
+    kpregistry_url: AnyUrl = "https://kp-registry.renci.org"
     omnicorp_url: AnyUrl = "http://robokop.renci.org:3210"
     biolink_url: AnyUrl = "https://bl-lookup-sri.renci.org"
     normalizer_url: AnyUrl = "https://nodenormalization-sri.renci.org"

--- a/strider/config.py
+++ b/strider/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     kpregistry_url: AnyUrl = "https://kp-registry.renci.org"
     omnicorp_url: AnyUrl = "http://robokop.renci.org:3210"
     biolink_url: AnyUrl = "https://bl-lookup-sri.renci.org"
-    normalizer_url: AnyUrl = "https://nodenormalization-sri.renci.org"
+    normalizer_url: AnyUrl = "https://nodenormalization-sri.renci.org/1.1"
 
     redis_url: RedisDsn = "redis://localhost"
     store_results_for: timedelta = timedelta(days=7)

--- a/strider/server.py
+++ b/strider/server.py
@@ -49,7 +49,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="2.0.3",
+    version="2.0.4",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/strider/server.py
+++ b/strider/server.py
@@ -313,11 +313,12 @@ async def custom_swagger_ui_html(req: Request) -> HTMLResponse:
     """Customize Swagger UI."""
     root_path = req.scope.get("root_path", "").rstrip("/")
     openapi_url = root_path + APP.openapi_url
+    swagger_favicon_url = root_path + "/static/favicon.svg"
     return get_swagger_ui_html(
         openapi_url=openapi_url,
         title=APP.title + " - Swagger UI",
         oauth2_redirect_url=APP.swagger_ui_oauth2_redirect_url,
-        swagger_favicon_url="/static/favicon.svg",
+        swagger_favicon_url=swagger_favicon_url,
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -614,11 +614,13 @@ async def test_kp_not_trapi():
     "http://ctd/query",
     Response(
         status_code=200,
-        content=json.dumps({"message": {
-            "query_graph": None,
-            "knowledge_graph": None,
-            "results": None,
-        }}),
+        content=json.dumps({
+            "message": {
+                "query_graph": None,
+                "knowledge_graph": None,
+                "results": None,
+            }
+        }),
     )
 )
 async def test_kp_response_empty():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -649,7 +649,7 @@ async def test_kp_response_no_qg():
     response = await client.post("/query", json=q)
     output = response.json()
 
-    # Check that we stored the error
+    # Check that there are no logged errors.
     assert not output["logs"]
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -635,7 +635,11 @@ async def test_kp_response_empty():
     )
 
     # Create query
-    q = {"message" : {"query_graph" : QGRAPH}}
+    q = {
+        "message" : {
+            "query_graph" : QGRAPH
+        }
+    }
 
     # Run
     response = await client.post("/query", json=q)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -622,9 +622,12 @@ async def test_kp_not_trapi():
         }),
     )
 )
-async def test_kp_response_empty():
+async def test_kp_response_no_qg():
     """
-    Test that when a KP returns null query graph
+    Test when a KP returns null query graph.
+
+    This used to cause an error in our code, which was caught and logged.
+    It is now handled immediately, so we should not log any errors.
     """
     QGRAPH = query_graph_from_string(
         """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -598,8 +598,7 @@ async def test_kp_not_trapi():
 @with_registry_overlay(
     settings.kpregistry_url, {
         'ctd': {
-            'url':
-            'http://ctd/query',
+            'url': 'http://ctd/query',
             'operations': [{
                 'source_type': 'biolink:ChemicalSubstance',
                 'edge_type': '-biolink:treats->',


### PR DESCRIPTION
* Fix favicon path
* Exclude unset fields from KP queries
* Fix default KP registry URL
* Handle KP responses with no qgraph
* Update nodenorm URL to TRAPI 1.1 instance