### PR TITLE
Reformat provenance

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,6 +1,6 @@
 aiofiles==0.6.0
 aiosqlite==0.13.0
-anyio==3.2.1
+anyio==3.3.0
 bmt-lite-1.8.2==1.0.2
 certifi==2021.5.30
 click==7.1.2

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -117,10 +117,10 @@ def add_source(message: Message):
     """Add provenance annotation to kedges.
        Sources from which we retrieve data add their own prov, we add prov for aragorn."""
     for kedge in message["knowledge_graph"]["edges"].values():
-        kedge["attributes"] = [dict(
+        kedge["attributes"].append(dict(
             attribute_type_id="biolink:aggregator_knowledge_source",
             value="infores:aragorn",
-        )]
+        ))
 
 
 Entity = namedtuple("Entity", ["categories", "identifiers"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1660,6 +1660,7 @@ async def test_provenance():
     ]
     assert "infores:aragorn" in values
     assert "infores:kp0" in values
+    assert "infores:kp1" not in values
     assert "biolink:aggregator_knowledge_source" in attribute_type_ids
     assert "biolink:knowledge_source" in attribute_type_ids
     assert values.index("infores:aragorn") == attribute_type_ids.index("biolink:aggregator_knowledge_source")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1659,6 +1659,6 @@ async def test_provenance():
         [i["attribute_type_id"] for i in attributes]
     ]
     assert "infores:aragorn" in provenance[0]
-    assert "infores:None" in provenance[0]
+    assert "infores:kp0" in provenance[0]
     assert "biolink:aggregator_knowledge_source" in provenance[1]
     assert "biolink:knowledge_source" in provenance[1]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1651,14 +1651,16 @@ async def test_provenance():
     response = await client.post("/query", json=q)
     output = response.json()
     edge = list(output["message"]["knowledge_graph"]["edges"].values())[0]
-    attributes = [
-        attribute for attribute in edge["attributes"]
+    attributes = edge["attributes"]
+    values = [
+        i["value"] for i in attributes
     ]
-    provenance = [
-        [i["value"] for i in attributes],
-        [i["attribute_type_id"] for i in attributes]
+    attribute_type_ids = [
+        i["attribute_type_id"] for i in attributes
     ]
-    assert "infores:aragorn" in provenance[0]
-    assert "infores:kp0" in provenance[0]
-    assert "biolink:aggregator_knowledge_source" in provenance[1]
-    assert "biolink:knowledge_source" in provenance[1]
+    assert "infores:aragorn" in values
+    assert "infores:kp0" in values
+    assert "biolink:aggregator_knowledge_source" in attribute_type_ids
+    assert "biolink:knowledge_source" in attribute_type_ids
+    assert values.index("infores:aragorn") == attribute_type_ids.index("biolink:aggregator_knowledge_source")
+    assert values.index("infores:kp0") == attribute_type_ids.index("biolink:knowledge_source")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1647,9 +1647,13 @@ async def test_provenance():
     # Run
     response = await client.post("/query", json=q)
     output = response.json()
-    print(output)
     edges = output["message"]["knowledge_graph"]["edges"]
-    attributes = [
-        edges[edge]["attributes"] for edge in edges
+    attribute = [
+        edge["attributes"][0] for edge in edges.values()
     ]
-    assert "infores:aragorn" in attributes[0][0]["value"]
+    provenance = [
+        [i["value"] for i in attribute],
+        [i["attribute_type_id"] for i in attribute]
+    ]
+    assert "infores:aragorn" in provenance[0]
+    assert "biolink:aggregator_knowledge_source" in provenance[1]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1635,6 +1635,9 @@ async def test_multiple_identifiers():
         """
 )
 async def test_provenance():
+    """
+    Tests that provenance is properly reported by strider.
+    """
     QGRAPH = query_graph_from_string(
         """
         n0(( ids[] MONDO:0005148 ))
@@ -1647,13 +1650,15 @@ async def test_provenance():
     # Run
     response = await client.post("/query", json=q)
     output = response.json()
-    edges = output["message"]["knowledge_graph"]["edges"]
-    attribute = [
-        edge["attributes"][0] for edge in edges.values()
+    edge = list(output["message"]["knowledge_graph"]["edges"].values())[0]
+    attributes = [
+        attribute for attribute in edge["attributes"]
     ]
     provenance = [
-        [i["value"] for i in attribute],
-        [i["attribute_type_id"] for i in attribute]
+        [i["value"] for i in attributes],
+        [i["attribute_type_id"] for i in attributes]
     ]
     assert "infores:aragorn" in provenance[0]
+    assert "infores:None" in provenance[0]
     assert "biolink:aggregator_knowledge_source" in provenance[1]
+    assert "biolink:knowledge_source" in provenance[1]


### PR DESCRIPTION
Added testing for provenance and adjusted edge attributes to report provenance for strider while also preserving provenance from KP's. Test ensures that provenance is included within edges.

Note:
Test may need to be adjusted if simple-kp/binder-kp appropriately reports KP name. Currently, it doesn't look like it does that correctly.