### PR TITLE
url for node norm has changed to nodenormalization-sri-dev.renci.org

### DIFF
--- a/strider/config.py
+++ b/strider/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     kpregistry_url: AnyUrl = "https://kp-registry.renci.org"
     omnicorp_url: AnyUrl = "http://robokop.renci.org:3210"
     biolink_url: AnyUrl = "https://bl-lookup-sri.renci.org"
-    normalizer_url: AnyUrl = "https://nodenormalization-sri.renci.org/1.1"
+    normalizer_url: AnyUrl = "https://nodenormalization-sri-dev.renci.org/1.1"
 
     redis_url: RedisDsn = "redis://localhost"
     store_results_for: timedelta = timedelta(days=7)


### PR DESCRIPTION
like the title says