### PR TITLE
Batch Strider threads for speed

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -21,6 +21,6 @@ redis==3.5.3
 rfc3986==1.5.0
 sniffio==1.2.0
 starlette==0.14.2
-trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@ce9c92b6b434d2ece233640608ea14615a0cec3c
+trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@e9ba94941cb04c72e41551de53c0e92f262a8721
 typing-extensions==3.10.0.0
 uvicorn==0.13.4

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -38,6 +38,6 @@ sniffio==1.2.0
 sortedcontainers==2.4.0
 starlette==0.14.2
 toml==0.10.2
-trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@ce9c92b6b434d2ece233640608ea14615a0cec3c
+trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@e9ba94941cb04c72e41551de53c0e92f262a8721
 typing-extensions==3.10.0.0
 uvicorn==0.13.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,5 +22,5 @@ pytest==6.2.4
 pytest-asyncio==0.15.1
 pytest-cov==2.12.1
 binder @ git+git://github.com/TranslatorSRI/binder@v4.2.3
-trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@v1.2.0
+trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@v1.2.1
 orjson==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ jsonpickle==1.4.2
 python-dotenv==0.17.0
 fastapi==0.65.2
 reasoner-pydantic==1.1.2.1
-trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@v1.2.0
+trapi-throttle @ git+git://github.com/ranking-agent/trapi-throttle@v1.2.1
 orjson==3.6.0

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -150,7 +150,7 @@ def add_source(message: Message):
     """Add provenance annotation to kedges.
        Sources from which we retrieve data add their own prov, we add prov for aragorn."""
     for kedge in message["knowledge_graph"]["edges"].values():
-        kedge["attributes"] = kedge.get("attributes", []) + [dict(
+        kedge["attributes"] = (kedge.get("attributes", None) or []) + [dict(
             attribute_type_id="biolink:aggregator_knowledge_source",
             value="infores:aragorn",
         )]

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -97,10 +97,13 @@ class KnowledgePortal():
             self,
             message: Message,
             prefixes: dict[str, list[str]],
+            logger: logging.Logger = None,
     ) -> Message:
         """Map prefixes."""
+        if not logger:
+            logger = self.logger
         await self.synonymizer.load_message(message)
-        curie_map = self.synonymizer.map(prefixes)
+        curie_map = self.synonymizer.map(prefixes, logger)
         return apply_curie_map(message, curie_map)
 
     async def fetch(
@@ -228,9 +231,11 @@ class Synonymizer():
         """Get preferred curie."""
         return self._data[curie]
 
-    def map(self, prefixes: dict[str, list[str]]):
+    def map(self, prefixes: dict[str, list[str]], logger: logging.Logger = None):
         """Generate CURIE map."""
-        return CURIEMap(self._data, prefixes, self.logger)
+        if not logger:
+            logger = self.logger
+        return CURIEMap(self._data, prefixes, logger)
 
 
 class CURIEMap():
@@ -276,7 +281,8 @@ class CURIEMap():
 
         # no preferred curie with these prefixes
         self.logger.warning(
-            "Cannot find identifier in {} with a preferred prefix in {}".format(
+            "[{}] Cannot find identifier in {} with a preferred prefix in {}".format(
+                getattr(self.logger, "context"),
                 identifiers,
                 prefixes,
             ),

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -280,7 +280,7 @@ class CURIEMap():
             return prefix_identifiers
 
         # no preferred curie with these prefixes
-        self.logger.warning(
+        self.logger.debug(
             "[{}] Cannot find identifier in {} with a preferred prefix in {}".format(
                 getattr(self.logger, "context"),
                 identifiers,

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -64,6 +64,13 @@ class ReasonerLogEntryFormatter(logging.Formatter):
         return log_entry
 
 
+_logger = logging.getLogger(__name__)
+sh = logging.StreamHandler()
+formatter = logging.Formatter("[%(asctime)s: %(levelname)s/%(name)s]: %(message)s")
+sh.setFormatter(formatter)
+_logger.addHandler(sh)
+
+
 class Binder():
     """Binder."""
 

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -356,7 +356,7 @@ class Binder():
             except JSONDecodeError as err:
                 self.logger.warning(
                     "Unable to parse meta knowledge graph from KP {}: {}".format(
-                        kp["id"],
+                        kp_id,
                         str(err),
                     ),
                 )

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -158,7 +158,7 @@ class Binder():
         )
         onehop_kgraph = onehop_response["knowledge_graph"]
         onehop_results = onehop_response["results"]
-        qedge_id = next(iter(qgraph["edges"].keys()))
+        qedge_id = next(iter(onehop_qgraph["edges"].keys()))
         generators = []
 
         if onehop_results:

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -286,8 +286,10 @@ class Binder():
 
     def get_processor(self, preferred_prefixes):
         """Get processor."""
-        async def processor(request):
+        async def processor(request, logger: logging.Logger = None):
             """Map message CURIE prefixes."""
+            if logger is None:
+                logger = self.logger
             request["message"] = await self.portal.map_prefixes(request["message"], preferred_prefixes)
             return request
         return processor

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -166,7 +166,7 @@ async def generate_plan(
         )
         if not kp_results:
             msg = f"No KPs for qedge '{qedge_id}'"
-            logger.error(msg)
+            logger.info(msg)
             raise NoAnswersError(msg)
         for kp in kp_results.values():
             for op in kp["operations"]:

--- a/strider/server.py
+++ b/strider/server.py
@@ -41,7 +41,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="3.6.0",
+    version="3.7.0",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/strider/util.py
+++ b/strider/util.py
@@ -2,7 +2,7 @@
 import functools
 from json.decoder import JSONDecodeError
 import re
-from typing import Callable, Union
+from typing import Callable, Iterable, Union
 
 import httpx
 from starlette.middleware.cors import CORSMiddleware
@@ -233,6 +233,13 @@ def ensure_list(arg: Union[str, list[str]]) -> list[str]:
     if isinstance(arg, list):
         return arg
     return [arg]
+
+
+def batch(iterable: Iterable, n: int = 1):
+    """Batch things into batches of size n."""
+    N = len(iterable)
+    for ndx in range(0, N, n):
+        yield iterable[ndx:min(ndx + n, N)]
 
 
 def listify_value(input_dictionary: dict[str, any], key: str):

--- a/strider/util.py
+++ b/strider/util.py
@@ -165,21 +165,21 @@ async def post_json(url, request, logger, log_name):
             response.raise_for_status()
             return response.json()
     except httpx.ReadTimeout as e:
-        logger.error({
+        logger.warning({
             "message": f"{log_name} took >60 seconds to respond",
             "error": str(e),
             "request": log_request(e.request),
         })
     except httpx.RequestError as e:
         # Log error
-        logger.error({
+        logger.warning({
             "message": f"Request Error contacting {log_name}",
             "error": str(e),
             "request": log_request(e.request),
         })
     except httpx.HTTPStatusError as e:
         # Log error with response
-        logger.error({
+        logger.warning({
             "message": f"Response Error contacting {log_name}",
             "error": str(e),
             "request": log_request(e.request),
@@ -187,7 +187,7 @@ async def post_json(url, request, logger, log_name):
         })
     except JSONDecodeError as e:
         # Log error with response
-        logger.error({
+        logger.warning({
             "message": f"Received bad JSON data from {log_name}",
             "request": e.request,
             "response": e.response.text,

--- a/strider/util.py
+++ b/strider/util.py
@@ -31,6 +31,13 @@ def function_to_mapping(f):
             else:
                 return value
 
+        def get(self, lookup, default=None):
+            value = f(lookup)
+            if value is None:
+                return default
+            else:
+                return value
+
         def __contains__(self, lookup):
             return f(lookup) is not None
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1491,7 +1491,10 @@ async def test_registry_normalizer_unavailable(client):
     )
 
     # Create query
-    q = {"message" : {"query_graph" : QGRAPH}}
+    q = {
+        "message" : {"query_graph" : QGRAPH},
+        "log_level": "WARNING",
+    }
 
     # Run
     response = await client.post("/query", json=q)


### PR DESCRIPTION
We seem to have been spending a lot of time managing the thousands of asyncio tasks. Now we have one "thread" per set of qedge-KP pairs. For example, for a two-hop query, we could have a thread for e0/KG2 + e01/ICEES.

This also works on improving logging.