### PR TITLE
Attribute comparison optimization

### DIFF
--- a/tests/test_trapi.py
+++ b/tests/test_trapi.py
@@ -76,10 +76,10 @@ ATTRIBUTE_B = {
 }
 
 def test_attribute_equality():
-    """ Test the build_attribute_unique_id function """
+    """ Test the attribute_hash function """
 
-    assert build_attribute_unique_id(ATTRIBUTE_A) != \
-           build_attribute_unique_id(ATTRIBUTE_B)
+    assert attribute_hash(ATTRIBUTE_A) != \
+           attribute_hash(ATTRIBUTE_B)
 
     # Test with sub-attributes
     ATTRIBUTE_WITH_SUBATTRIBUTES_A = {

--- a/tests/test_trapi.py
+++ b/tests/test_trapi.py
@@ -1,7 +1,7 @@
 import pytest
 
 from strider.trapi import \
-    filter_by_qgraph, canonicalize_qgraph, merge_messages
+    build_attribute_unique_id, filter_by_qgraph, canonicalize_qgraph, merge_messages
 
 
 @pytest.mark.asyncio
@@ -74,6 +74,29 @@ ATTRIBUTE_B = {
     "attribute_type_id": "biolink:is_bad",
     "value": True,
 }
+
+def test_attribute_equality():
+    """ Test the build_attribute_unique_id function """
+
+    assert build_attribute_unique_id(ATTRIBUTE_A) != \
+           build_attribute_unique_id(ATTRIBUTE_B)
+
+    # Test with sub-attributes
+    ATTRIBUTE_WITH_SUBATTRIBUTES_A = {
+        "attribute_type_id": "biolink:i_am_out_of_attribute_type_ideas",
+        "value": 4,
+        "attributes" : [ATTRIBUTE_A]
+    }
+    ATTRIBUTE_WITH_SUBATTRIBUTES_B = {
+        "attribute_type_id": "biolink:i_am_out_of_attribute_type_ideas",
+        "value": 4,
+        "attributes" : [ATTRIBUTE_A, ATTRIBUTE_B]
+    }
+
+    assert build_attribute_unique_id(ATTRIBUTE_WITH_SUBATTRIBUTES_A) != \
+           build_attribute_unique_id(ATTRIBUTE_WITH_SUBATTRIBUTES_B)
+
+
 
 
 def test_merge_knowledge_graph_nodes():

--- a/tests/test_trapi.py
+++ b/tests/test_trapi.py
@@ -1,7 +1,7 @@
 import pytest
 
 from strider.trapi import \
-    build_attribute_unique_id, filter_by_qgraph, canonicalize_qgraph, merge_messages
+    attribute_hash, filter_by_qgraph, canonicalize_qgraph, merge_messages
 
 
 @pytest.mark.asyncio
@@ -93,8 +93,8 @@ def test_attribute_equality():
         "attributes" : [ATTRIBUTE_A, ATTRIBUTE_B]
     }
 
-    assert build_attribute_unique_id(ATTRIBUTE_WITH_SUBATTRIBUTES_A) != \
-           build_attribute_unique_id(ATTRIBUTE_WITH_SUBATTRIBUTES_B)
+    assert attribute_hash(ATTRIBUTE_WITH_SUBATTRIBUTES_A) != \
+           attribute_hash(ATTRIBUTE_WITH_SUBATTRIBUTES_B)
 
 
 


### PR DESCRIPTION
This PR targets attribute deduplication, a piece of code that is particularly slow for some queries (see #276). The fix here was to speed up deduplication by switching from a JSON based comparison to a custom hash function. This results in about a 40% speedup on #276. Unfortunately, this is not enough of a speedup to enable smart attribute merging, so for now this is disabled.