### PR TITLE
Add profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This will start the requisite containers as well as the strider container. Chang
 
 You can also run tests and coverage reports withou the management script. Check the `manage.py` file for instructions on how to do this.
 
+### Profiler
+
+The local development environment also includes a built-in profiler for debugging performance issues. To use this, set `PROFILER=true` in a `.env` file in the root of the repository. Once the application is running the profiler will automatically be run on all incoming requests. To view profiles you can visit [localhost:5781/profiles](http://localhost:5781/profiles), which will give you a list of the captured profiles. These captured profiles can be used with the [snakeviz](https://jiffyclub.github.io/snakeviz/) utility to easily diagnose performance issues.
+
 ## [Testing](tests/README.md)
 
 ## Deployment

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,3 +23,4 @@ sniffio==1.2.0
 starlette==0.14.2
 typing-extensions==3.10.0.2
 uvicorn==0.13.4
+yappi==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv==0.17.0
 fastapi==0.65.2
 reasoner-pydantic==1.2.0.2
 orjson==3.6.0
+yappi==1.3.2

--- a/strider/config.py
+++ b/strider/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
 
     redis_url: RedisDsn = "redis://localhost"
     store_results_for: timedelta = timedelta(days=7)
+    profiler: bool = False
 
     class Config:
         env_file = ".env"

--- a/strider/profiler.py
+++ b/strider/profiler.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import time
+
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import HTMLResponse
+import yappi
+
+from .server import APP
+
+# Create directory to store request profile data
+PROFILE_DIRECTORY = "/profiles"
+Path(PROFILE_DIRECTORY).mkdir(exist_ok = True)
+
+# Middleware to capture profile data and save it
+# to files
+@APP.middleware("http")
+async def profiler_middleware(request, call_next):
+    # Run the request
+    with yappi.run():
+        call_result = await call_next(request)
+
+    # Save profile
+    stats = yappi.get_func_stats()
+    stats.save(f"{PROFILE_DIRECTORY}/req-{time.time()}.prof", type='pstat')
+
+    # Continue
+    return call_result
+
+# Serve prof files under /profiles/
+APP.mount("/profiles",
+          StaticFiles(directory=PROFILE_DIRECTORY),
+          name="profiles",
+          )
+
+@APP.get("/profiles", response_class=HTMLResponse)
+async def profiles_list():
+    """ Helper page that lists available profiles to download """
+
+    profile_links = [
+        f"<li><a href='/profiles/{p.name}' download>{p.stem}</a></li>"
+        for p in Path(PROFILE_DIRECTORY).iterdir()
+    ]
+
+    return f"""
+    <html>
+        <head>
+            <title>Strider Profiles</title>
+        </head>
+        <body>
+            <h1>Available request profiles for download:</h1>
+            <ul>
+                {"".join(profile_links)}
+            </ul>
+        </body>
+    </html>
+    """

--- a/strider/profiler.py
+++ b/strider/profiler.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import time
+import uuid
 
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse
@@ -7,9 +8,21 @@ import yappi
 
 from .server import APP
 
+class DownloadStaticFiles(StaticFiles):
+    """
+    Wrapper on StaticFiles to serve files that are automatically
+    downloaded using the Content-Disposition header
+    """
+    def file_response(*args, **kwargs):
+        resp = StaticFiles.file_response(*args, **kwargs)
+        resp.headers["Content-Disposition"] = "attachment"
+        return resp
+
 # Create directory to store request profile data
 PROFILE_DIRECTORY = "/profiles"
 Path(PROFILE_DIRECTORY).mkdir(exist_ok = True)
+
+captured_profiles = []
 
 # Middleware to capture profile data and save it
 # to files
@@ -19,38 +32,34 @@ async def profiler_middleware(request, call_next):
     with yappi.run():
         call_result = await call_next(request)
 
+    # Generate ID for this request
+    request_id = str(uuid.uuid1())
+
     # Save profile
     stats = yappi.get_func_stats()
-    stats.save(f"{PROFILE_DIRECTORY}/req-{time.time()}.prof", type='pstat')
+    stats.save(f"{PROFILE_DIRECTORY}/{request_id}.prof", type='pstat')
+
+    download_link = \
+        f"{request.url.scheme}://{request.url.netloc}/profiles/{request_id}.prof"
+
+    # Save profile meta-info
+    captured_profiles.append({
+        "id" : request_id,
+        "timestamp" : time.time(),
+        "path" : request.url.path,
+        "download_link" : download_link,
+    })
 
     # Continue
     return call_result
 
 # Serve prof files under /profiles/
 APP.mount("/profiles",
-          StaticFiles(directory=PROFILE_DIRECTORY),
+          DownloadStaticFiles(directory=PROFILE_DIRECTORY),
           name="profiles",
           )
 
-@APP.get("/profiles", response_class=HTMLResponse)
+@APP.get("/profiles")
 async def profiles_list():
-    """ Helper page that lists available profiles to download """
-
-    profile_links = [
-        f"<li><a href='/profiles/{p.name}' download>{p.stem}</a></li>"
-        for p in Path(PROFILE_DIRECTORY).iterdir()
-    ]
-
-    return f"""
-    <html>
-        <head>
-            <title>Strider Profiles</title>
-        </head>
-        <body>
-            <h1>Available request profiles for download:</h1>
-            <ul>
-                {"".join(profile_links)}
-            </ul>
-        </body>
-    </html>
-    """
+    """ Get all profiles captured in the current session"""
+    return captured_profiles

--- a/strider/profiler.py
+++ b/strider/profiler.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+import tempfile
 import time
 import uuid
 
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse
 import yappi
 
 from .server import APP
@@ -19,8 +19,7 @@ class DownloadStaticFiles(StaticFiles):
         return resp
 
 # Create directory to store request profile data
-PROFILE_DIRECTORY = "/profiles"
-Path(PROFILE_DIRECTORY).mkdir(exist_ok = True)
+PROFILE_DIRECTORY = tempfile.mkdtemp()
 
 captured_profiles = []
 

--- a/strider/server.py
+++ b/strider/server.py
@@ -79,8 +79,12 @@ APP.add_middleware(
     **CORS_OPTIONS,
 )
 
+if settings.profiler:
+    from .profiler import profiler_middleware
+
 # Custom exception handler is necessary to ensure that
 # we add CORS headers to errors and return a TRAPI response
+
 async def catch_exceptions_middleware(request: Request, call_next):
     try:
         return await call_next(request)


### PR DESCRIPTION
This PR adds a profiler that can be enabled with PROFILER=true environment variable. The profiler is available at localhost:5781/profiler and the generated profiles can be used with snakeviz for easy performance debugging. Fixes #277.

The only minor issue of this PR is that yappi is added to our deployed Dockerfile. There's not really a clean way to include it as a dev dependency (this would involve creating `requirements-dev.txt` and `requirements-dev-lock.txt` and `Dockerfile.dev`). I don't think it's going to be a big issue - yappi has no dependencies of its own and is not imported if PROFILER=true is not defined.