### PR TITLE
Compose volume path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .vscode/
 .vim/
 venv/
+.venv/
 .DS_Store
 *.egg-info/
 *.db
@@ -13,3 +14,4 @@ logs/*
 .env
 *.log
 data/
+.dir-locals.el

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,13 +5,13 @@ services:
   kp-registry:
     image: ghcr.io/ranking-agent/kp-registry:v2.2.0
     volumes:
-      - ./data:/home/murphy/data
+      - ./data:/app/data
     ports:
       - '4983:4983'
   # Set up reloading using volume mounts
   strider:
     volumes:
-      - ./:/home/murphy
+      - ./:/app
     command: --host 0.0.0.0 --port 5781 --reload
     environment:
       KPREGISTRY_URL: http://kp-registry:4983


### PR DESCRIPTION
Fixed a volume path issue in our docker-compose.dev.yml file. This was causing two issues:

* Automatic restarts on code changes were not working because the volume was not mounted in the correct place
* Passthrough of .env file for strider configuration wasn't working

Also updated .gitignore. Closes #281. 