### PR TITLE
Dependency Management Command Fix

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -80,13 +80,6 @@ jobs:
       - name: Exit if there are any test failures
         run: '[[ $TEST_OUTPUT != *FAILED* ]]'
 
-  check-format:
-    name: Check that code matches Black formatter
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: psf/black@stable
-
   verify-lock:
     name: Verify lockfiles are up to date
     runs-on: ubuntu-latest
@@ -96,3 +89,10 @@ jobs:
 
       - name: Verify lockfiles
         run: python manage.py verify_locked
+
+  check-format:
+    name: Check that code matches Black formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -86,3 +86,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
+
+  verify-lock:
+    name: Verify lockfiles are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Verify lockfiles
+        run: python manage.py verify_locked

--- a/manage.py
+++ b/manage.py
@@ -13,6 +13,7 @@ def run_command(cmd):
     print_green(cmd)
     os.system(cmd)
 
+
 def get_command_output(cmd):
     return os.popen(cmd).read()
 
@@ -113,31 +114,36 @@ def lock(extra_args):
         """
         run_command(command)
 
+
 def verify_locked(extra_args):
     """
     Verify that the lockfile is up-to-date
     """
 
     for src, locked in REQUIREMENTS_FILES.items():
-        dependencies = get_command_output(f"""\
+        dependencies = get_command_output(
+            f"""\
         docker run -v $(pwd):/app python:3.9 \
             /bin/bash -c "
                 pip install -qqq -r /app/{locked} &&
                 pip install -qqq -r /app/{src}    &&
                 pip freeze
             "
-        """)
-        lock_dependencies = get_command_output(f"""\
+        """
+        )
+        lock_dependencies = get_command_output(
+            f"""\
         docker run -v $(pwd):/app python:3.9 \
             /bin/bash -c "
                 pip install -qqq -r /app/{locked} &&
                 pip freeze
             "
-        """)
+        """
+        )
 
         if dependencies != lock_dependencies:
-            sys.exit(
-                f"Lock file {locked} not up-to-date, please run ./manage.py lock")
+            sys.exit(f"Lock file {locked} not up-to-date, please run ./manage.py lock")
+
 
 def upgrade(extra_args):
     """


### PR DESCRIPTION
Added separate `lock` and `upgrade` commands to make it possible to install dependencies without upgrading all dependencies to latest version. Also added a check for PRs to make sure that lockfiles are up-to-date.