### PR TITLE
Fix bug where neither inverse predicate is canonical

### DIFF
--- a/strider/trapi.py
+++ b/strider/trapi.py
@@ -319,7 +319,9 @@ def canonicalize_qedge(
             if inverse_slot is None:
                 predicates.append(predicate)
                 continue
-            is_canonical = inverse_slot.annotations.get("biolink:canonical_predicate", False)
+            is_canonical = inverse_slot.annotations.get(
+                "biolink:canonical_predicate", False
+            )
             # if inverse is marked canonical, use it
             if is_canonical:
                 flipped_predicates.append(bmt.util.format(slot.inverse, case="snake"))


### PR DESCRIPTION
This seems to be an issue in the Biolink Model, where `decreases_activity_of` has an inverse that is `activity_decreased_by`. Strider logic looks for the canonical predicate of the two, but neither is. In that case, we were still just flipping the predicate, and RTX doesn't have any results for `activity_decreased_by`. This PR just adds logic to check if the inverse is canonical, and if neither is, then we'll just use the original predicate given to us. We're also going to open an issue on Biolink Model to have them add the canonical property to one of these inverse predicates.