### PR TITLE
Fix independent results bug

### DIFF
--- a/docs/FETCHER.md
+++ b/docs/FETCHER.md
@@ -1,0 +1,177 @@
+# Fetcher
+
+## Task
+Given a question graph, we would like to generate results from multiple knowledge providers (KPs).
+
+However, suppose we can only query each KP using a single-edge question graph (aka one-hop).
+
+## Approach
+The fetcher generates results by sequentially querying each edge of the question graph.
+
+Here's a single step of that sequential process:
+
+1. **Select an edge**
+
+The fetcher selects the one-hop at each step that is estimated to produce the smallest number of results - e.g., question graphs with pinned nodes tend to produce fewer results than those with two unpinned nodes.
+
+```
+           one-hop edge
+ _____          |           ___________________                   ______
+|     |         v          |                   |                 |      |
+| Flu | --has_phenotype--> | PhenotypicFeature | --related_to--> | Drug |
+|_____|                    |___________________|                 |______|
+                  
+```
+
+2. **Query the KPs**
+
+Once the one-hop is selected, it is sent asynchronously to all relevant KPs, which each provide results. This information is stored (more on that later) to build each complete result later.
+
+```
+KP #1 Results:
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Cough |
+|_____|                    |_______|
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Fever |
+|_____|                    |_______|
+
+KP #2 Results:
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Fever |
+|_____|                    |_______|
+ _____                      __________
+|     |                    |          |
+| Flu | --has_phenotype--> | Headache |
+|_____|                    |__________|
+```
+
+3. **Update the question graph**
+
+For each KP, the fetcher creates a subgraph from the question graph (of step 1) *without the selected/one-hop edge*, and all orphans (nodes without neighbors) are removed. The endpoints of the selected edge are pinned using the identities retrieved from the KP's results.
+
+```
+KP #1 Subgraph:
+ ________________                   ______
+|                |                 |      |
+| {Cough, Fever} | --related_to--> | Drug |
+|________________|                 |______|
+
+KP #2 Subgraph
+ ___________________                   ______
+|                   |                 |      |
+| {Fever, Headache} | --related_to--> | Drug |
+|___________________|                 |______|
+
+```
+
+For each KP's subgraph, these three steps are run recursively until all edges have been queried. This recursion works because (1) it has a base case – a question graph without nodes/edges simply returns no results – and (2) each step makes progress toward the base case – the subgraph outputted at the end of step 3 is guaranteed to have 1 less edge than the input question graph at step 1.
+
+Once the base case is reached and each recursive call returns, the stored one-hop results (mentioned in step 2) are accessed to yield multiple complete results. The results of the subgraph ("given" by recursion/induction) can be used to construct the results of the original question graphs. Continuing the above example:
+```
+Question Graph:
+
+           one-hop edge
+ _____          |           ___________________                   ______
+|     |         v          |                   |                 |      |
+| Flu | --has_phenotype--> | PhenotypicFeature | --related_to--> | Drug |
+|_____|                    |___________________|                 |______|
+
+
+Results of one-hop:
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Cough |
+|_____|                    |_______|
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Fever |
+|_____|                    |_______|
+
+
+Subgraph (question graph without one-hop edge):
+ ________________                   ______
+|                |                 |      |
+| {Cough, Fever} | --related_to--> | Drug |
+|________________|                 |______|
+
+
+Complete results of subgraph (known because recursion/induction):
+ _______                   ___________
+|       |                 |           |
+| Fever | --related_to--> | Ibuprofen |
+|_______|                 |___________|
+ _______                   __________________
+|       |                 |                  |
+| Cough | --related_to--> | Dextromethorphan |
+|_______|                 |__________________|
+
+
+Complete results (combination of one-hop results and subgraph results):
+ _____                      _______                   ___________
+|     |                    |       |                 |           |
+| Flu | --has_phenotype--> | Fever | --related_to--> | Ibuprofen |
+|_____|                    |_______|                 |___________|
+ _____                      _______                   __________________
+|     |                    |       |                 |                  |
+| Flu | --has_phenotype--> | Cough | --related_to--> | Dextromethorphan |
+|_____|                    |_______|                 |__________________|
+```
+
+## Implementation
+
+The implementation details are described well in [COMPONENTS.md](https://github.com/ranking-agent/strider/blob/ff025060c55bf4f357a44f45cfd9288fa9c6a754/docs/COMPONENTS.md). However, the process of stitching together the onehop results to form complete results is not well described.
+
+In `generate_from_results`, the fetcher combines the results of a subgraph with the results of the prior one-hop (missing from the subgraph) to produce the complete results of the question graph. Given a subgraph result, `get_results` uses `key_fcn` (defined in `generate_from_kp`) to identify the nodes in the subgraph result (and their identifiers) that are also nodes of the one-hop. `get_results` then uses `result_map` (also defined in `generate_from_kp`) to fetch the results of the one-hop that use the same identifier.
+
+For example, this pair of one-hop and subgraph results do share the same identifiers for nodes they have in common: 
+```
+One-hop result:
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Fever |
+|_____|                    |_______|
+
+Subgraph result:
+ _______                   ___________
+|       |                 |           |
+| Fever | --related_to--> | Ibuprofen |
+|_______|                 |___________|
+```
+while these two are not compatible.
+
+```
+One-hop result:
+ _____                      _______
+|     |                    |       |
+| Flu | --has_phenotype--> | Cough |
+|_____|                    |_______|
+
+Subgraph result:
+ _______                   ___________
+|       |                 |           |
+| Fever | --related_to--> | Ibuprofen |
+|_______|                 |___________|
+```
+
+Following up on this example with some code:
+```python
+                 _____                      _______
+                |     |                    |       |
+onehop_result = | Flu | --has_phenotype--> | Fever |
+                |_____|                    |_______|
+                  n0                          n1
+                   _______                   ___________
+                  |       |                 |           |
+subgraph_result = | Fever | --related_to--> | Ibuprofen |
+                  |_______|                 |___________|
+                     n1                          n2
+
+# Question graph and subgraph result both have n1, and
+# in the subgraph result, n1 has the identifier Fever
+assert key_fcn(subgraph_result) == (('n1', 'Fever'),)
+assert onehop_result in result_map[key_fcn(subgraph_result)]
+```

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -230,7 +230,7 @@ class Binder:
         ):
             for result, kgraph in get_results(subresult):
                 # combine one-hop with subquery results
-                subresult = {
+                new_subresult = {
                     "node_bindings": {
                         **subresult["node_bindings"],
                         **result["node_bindings"],
@@ -240,9 +240,10 @@ class Binder:
                         **result["edge_bindings"],
                     },
                 }
-                subkgraph["nodes"].update(kgraph["nodes"])
-                subkgraph["edges"].update(kgraph["edges"])
-                yield subkgraph, subresult
+                new_subkgraph = copy.deepcopy(subkgraph)
+                new_subkgraph["nodes"].update(kgraph["nodes"])
+                new_subkgraph["edges"].update(kgraph["edges"])
+                yield new_subkgraph, new_subresult
 
     async def __aenter__(self):
         """Enter context."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2100,6 +2100,7 @@ async def test_large_merging_performance(client):
     # Check that we only have one result
     assert len(output["message"]["results"]) == 1
 
+
 @pytest.mark.asyncio
 @with_translator_overlay(
     settings.kpregistry_url,
@@ -2118,7 +2119,7 @@ async def test_large_merging_performance(client):
         """
     },
 )
-async def test_yield_indepedent_results(client):
+async def test_yield_independent_results(client):
     """Test that when we ask for a solution, it's provided as independent results that are merged together"""
     QGRAPH = query_graph_from_string(
         """
@@ -2131,9 +2132,10 @@ async def test_yield_indepedent_results(client):
         """
     )
 
-    binder = Binder("test-qid", 10, redis_client=fakeredis.FakeRedis(
-        encoding="utf-8",
-        decode_responses=True)
+    binder = Binder(
+        "test-qid",
+        10,
+        redis_client=fakeredis.FakeRedis(encoding="utf-8", decode_responses=True),
     )
     await binder.setup(QGRAPH)
 
@@ -2142,8 +2144,6 @@ async def test_yield_indepedent_results(client):
 
     # 2 results
     assert len(output) == 2
-
-    breakpoint()
 
     # 3 knodes each (n0, n1, n2)
     assert len(output[0][0]["nodes"]) == 3


### PR DESCRIPTION
Fixes a bug in `fetcher.py` that caused unnecessary nodes to appear in kgraphs provided by `lookup()`. The fix helps merge time.

The fetcher was unintentionally adding nodes and edges to the same intermediate kgraph used across multiple results, causing the size of the kgraph to grow with each subsequent result. We're now deepcopying the initial intermediate kgraph for separate use in each result.