### PR TITLE
use correct pydantic model fields in trapi throttle

### DIFF
--- a/strider/trapi_throttle/trapi.py
+++ b/strider/trapi_throttle/trapi.py
@@ -95,15 +95,15 @@ def filter_by_curie_mapping(
     }
 
     # Construct result-specific knowledge graph
-    filtered_msg.kgraph = KnowledgeGraph(
+    filtered_msg.knowledge_graph = KnowledgeGraph(
         nodes={
-            binding["id"]: message.knowledge_graph.nodes[binding["id"]]
+            binding.id: message.knowledge_graph.nodes[binding.id]
             for result in filtered_msg.results
             for _, bindings in result.node_bindings.items()
             for binding in bindings
         },
         edges={
-            binding["id"]: message.knowledge_graph.edges[binding["id"]]
+            binding.id: message.knowledge_graph.edges[binding.id]
             for result in filtered_msg.results
             for _, bindings in result.edge_bindings.items()
             for binding in bindings


### PR DESCRIPTION
This fixes an issue that is present among some multi-hop queries by properly utilizing pydantic models in trapi throttle. This should also close #353 and #354. 

However, this does bring up another pressing issue. When this error was present, strider would error out and then hang until reset. We need to have more robust error handling to ensure that this is not an issue in the future.