### PR TITLE
500 on bad query

### DIFF
--- a/strider/normalizer.py
+++ b/strider/normalizer.py
@@ -29,7 +29,7 @@ class Normalizer:
 
         types = []
         for c in curies:
-            if results[c] is None:
+            if results.get(c) is None:
                 self.logger.warning(f"Normalizer knows nothing about {c}")
                 continue
             types.extend(results[c]["type"])


### PR DESCRIPTION
This PR fixes the strider 500 on a bad query as mentioned in #362.

However, doing this also has some odd effects. For one thing, we actually do get some results now, which doesn't make sense to me. I don't really know how or why any KP would be sending us anything, but we are receiving response with 23 results back from Genetics KP. This clearly shouldn't be happening. 