### PR TITLE
Fix hanging bug

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -19,7 +19,7 @@ orjson==3.6.0
 pydantic==1.8.2
 python-dotenv==0.17.0
 PyYAML==5.4
-reasoner-pydantic==2.1.2
+reasoner-pydantic==2.2.2
 redis==3.5.3
 rfc3986==1.5.0
 sniffio==1.2.0

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -18,7 +18,7 @@ httpx==0.18.2
 idna==3.3
 iniconfig==1.1.1
 jsonpickle==1.4.2
-kp-registry @ git+https://github.com/ranking-agent/kp_registry@f55bde83e3c3c0921d8c724a6c5dd55341a2bf4a
+kp-registry @ git+https://github.com/ranking-agent/kp_registry@be6d4b0503b02d6c16b3660d03b445fb3303df14
 numpy==1.21.0
 orjson==3.6.0
 packaging==21.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,9 +1,9 @@
 asgiar==0.2.0
 fakeredis==1.5.0
-kp-registry @ git+https://github.com/ranking-agent/kp_registry@v2.2.0
+kp-registry @ git+https://github.com/ranking-agent/kp_registry
 pytest==6.2.4
 pytest-asyncio==0.15.1
 pytest-cov==2.12.1
-binder @ git+https://github.com/TranslatorSRI/binder@v4.3.2
+binder @ git+https://github.com/TranslatorSRI/binder
 orjson==3.6.0
 tqdm==4.62.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ uvicorn[standard]==0.14.0
 jsonpickle==1.4.2
 python-dotenv==0.17.0
 fastapi==0.65.2
-reasoner-pydantic==2.1.2
+reasoner-pydantic==2.2.2
 orjson==3.6.0
 yappi==1.3.2
 gunicorn==20.1.0

--- a/strider/compatibility.py
+++ b/strider/compatibility.py
@@ -122,9 +122,10 @@ class KnowledgePortal:
         if not logger:
             logger = self.logger
         curies = get_curies(message)
-        await self.synonymizer.load_curies(*curies)
-        curie_map = self.synonymizer.map(curies, prefixes, logger)
-        return apply_curie_map(message, curie_map)
+        if len(curies):
+            await self.synonymizer.load_curies(*curies)
+            curie_map = self.synonymizer.map(curies, prefixes, logger)
+            apply_curie_map(message, curie_map)
 
     async def fetch(
         self,
@@ -290,7 +291,7 @@ class Synonymizer:
         if not prefixes:
             # There are no preferred prefixes for these categories - use the prefixes that Biolink prefers
             logger.debug(
-                "[{}] Cannot not find preferred prefixes for at least one of: {}".format(
+                "[{}] Cannot find preferred prefixes for at least one of: {}".format(
                     getattr(logger, "context", ""),
                     categories,
                 )

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -277,9 +277,10 @@ class Binder:
         # Update qgraph identifiers
         message = Message.parse_obj({"query_graph": qgraph})
         curies = get_curies(message)
-        await self.synonymizer.load_curies(*curies)
-        curie_map = self.synonymizer.map(curies, self.preferred_prefixes)
-        map_qgraph_curies(message.query_graph, curie_map, primary=True)
+        if len(curies):
+            await self.synonymizer.load_curies(*curies)
+            curie_map = self.synonymizer.map(curies, self.preferred_prefixes)
+            map_qgraph_curies(message.query_graph, curie_map, primary=True)
 
         self.qgraph = message.query_graph.dict()
 
@@ -289,7 +290,6 @@ class Binder:
         # Initialize registry
         registry = Registry(settings.kpregistry_url, self.logger)
 
-        self.logger.debug("Generating plan")
         # Generate traversal plan
         self.plan, kps = await generate_plan(
             self.qgraph,

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -134,7 +134,9 @@ class Binder:
         }
 
         generators = [
-            self.generate_from_kp(qgraph, onehop, self.kps[kp_id], copy.deepcopy(call_stack))
+            self.generate_from_kp(
+                qgraph, onehop, self.kps[kp_id], copy.deepcopy(call_stack)
+            )
             for kp_id in self.plan[qedge_id]
         ]
         async with aiostream.stream.merge(*generators).stream() as streamer:
@@ -167,7 +169,9 @@ class Binder:
             # remove orphaned nodes
             subqgraph.remove_orphaned()
         else:
-            self.logger.debug(f"Ending call stack with no results: {(', ').join(call_stack)}")
+            self.logger.debug(
+                f"Ending call stack with no results: {(', ').join(call_stack)}"
+            )
         for batch_results in batch(onehop_results, 1_000_000):
             result_map = defaultdict(list)
             for result in batch_results:
@@ -226,7 +230,8 @@ class Binder:
         call_stack: List,
     ):
         async for subkgraph, subresult in self.lookup(
-            qgraph, call_stack,
+            qgraph,
+            call_stack,
         ):
             for result, kgraph in get_results(subresult):
                 # combine one-hop with subquery results

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -9,30 +9,26 @@ oo     .d8P   888 .  888      888  888   888  888    .o  888
 8""88888P'    "888" d888b    o888o `Y8bod88P" `Y8bod8P' d888b
 
 """
-import asyncio
 from collections import defaultdict
 from collections.abc import Iterable
 import copy
-from itertools import chain
 from json.decoder import JSONDecodeError
 import logging
 from datetime import datetime
 
 from strider.constraints import enforce_constraints
-from typing import Any, Callable, Optional
+from typing import Callable, Optional, List
 
 import aiostream
 import httpx
 import pydantic
-from reasoner_pydantic import QueryGraph, Result, Response, MetaKnowledgeGraph, Message
+from reasoner_pydantic import MetaKnowledgeGraph, Message
 from redis import Redis
 
 from .trapi_throttle.throttle import ThrottledServer
 from .graph import Graph
 from .compatibility import KnowledgePortal, Synonymizer
 from .trapi import (
-    get_canonical_qgraphs,
-    filter_by_qgraph,
     get_curies,
     map_qgraph_curies,
     fill_categories_predicates,
@@ -108,18 +104,19 @@ class Binder:
     async def lookup(
         self,
         qgraph: Graph = None,
+        call_stack: List = [],
     ):
         """Expand from query graph node."""
         # if this is a leaf node, we're done
         if qgraph is None:
             qgraph = Graph(self.qgraph)
         if not qgraph["edges"]:
+            self.logger.debug(f"Finished call stack: {(', ').join(call_stack)}")
             yield {"nodes": dict(), "edges": dict()}, {
                 "node_bindings": dict(),
                 "edge_bindings": dict(),
             }
             return
-        self.logger.debug(f"Lookup for qgraph: {qgraph}")
 
         try:
             qedge_id, qedge = get_next_qedge(qgraph)
@@ -137,7 +134,7 @@ class Binder:
         }
 
         generators = [
-            self.generate_from_kp(qgraph, onehop, self.kps[kp_id])
+            self.generate_from_kp(qgraph, onehop, self.kps[kp_id], copy.deepcopy(call_stack))
             for kp_id in self.plan[qedge_id]
         ]
         async with aiostream.stream.merge(*generators).stream() as streamer:
@@ -149,8 +146,11 @@ class Binder:
         qgraph,
         onehop_qgraph,
         kp: KnowledgeProvider,
+        call_stack: List,
     ):
         """Generate one-hop results from KP."""
+        # keep track of call stack for each kp plan branch
+        call_stack.append(kp.id)
         onehop_response = await kp.solve_onehop(
             onehop_qgraph,
         )
@@ -166,6 +166,8 @@ class Binder:
             subqgraph["edges"].pop(qedge_id)
             # remove orphaned nodes
             subqgraph.remove_orphaned()
+        else:
+            self.logger.debug(f"Ending call stack with no results: {(', ').join(call_stack)}")
         for batch_results in batch(onehop_results, 1_000_000):
             result_map = defaultdict(list)
             for result in batch_results:
@@ -209,6 +211,7 @@ class Binder:
                 self.generate_from_result(
                     copy.deepcopy(subqgraph),
                     lambda result: result_map[key_fcn(result)],
+                    call_stack,
                 )
             )
 
@@ -220,13 +223,10 @@ class Binder:
         self,
         qgraph,
         get_results: Callable[[dict], Iterable[tuple[dict, dict]]],
+        call_stack: List,
     ):
-        # LOGGER.debug(
-        #     "Expanding from result %s...",
-        #     result,
-        # )
         async for subkgraph, subresult in self.lookup(
-            qgraph,
+            qgraph, call_stack,
         ):
             for result, kgraph in get_results(subresult):
                 # combine one-hop with subquery results

--- a/strider/trapi_throttle/throttle.py
+++ b/strider/trapi_throttle/throttle.py
@@ -288,9 +288,7 @@ class ThrottledServer:
                             filtered_msg = filter_by_curie_mapping(
                                 message, curie_mapping, kp_id=self.id
                             )
-                            filtered_msg.query_graph = QueryGraph.parse_obj(
-                                request_value_mapping[request_id]
-                            )
+                            filtered_msg.query_graph = request_value_mapping[request_id].message.query_graph.copy()
                             response_values[request_id] = ReasonerResponse(
                                 message=filtered_msg
                             )

--- a/strider/trapi_throttle/throttle.py
+++ b/strider/trapi_throttle/throttle.py
@@ -266,25 +266,25 @@ class ThrottledServer:
                     )
                 )
 
-                if len(request_curie_mapping) == 1:
-                    request_id = next(iter(request_curie_mapping))
-                    # Make a copy
-                    response_values[request_id] = ReasonerResponse(message=Message())
-                    response_values[
-                        request_id
-                    ].message.query_graph = request_value_mapping[
-                        request_id
-                    ].message.query_graph.copy()
-                    response_values[request_id].message.knowledge_graph = (
-                        message.knowledge_graph or KnowledgeGraph(nodes={}, edges={})
-                    ).copy()
-                    response_values[request_id].message.results = (
-                        message.results or HashableSet(__root__=[])
-                    ).copy()
-                else:
-                    # Split using the request_curie_mapping
-                    for request_id, curie_mapping in request_curie_mapping.items():
-                        try:
+                try:
+                    if len(request_curie_mapping) == 1:
+                        request_id = next(iter(request_curie_mapping))
+                        # Make a copy
+                        response_values[request_id] = ReasonerResponse(message=Message())
+                        response_values[
+                            request_id
+                        ].message.query_graph = request_value_mapping[
+                            request_id
+                        ].message.query_graph.copy()
+                        response_values[request_id].message.knowledge_graph = (
+                            message.knowledge_graph or KnowledgeGraph(nodes={}, edges={})
+                        ).copy()
+                        response_values[request_id].message.results = (
+                            message.results or HashableSet(__root__=[])
+                        ).copy()
+                    else:
+                        # Split using the request_curie_mapping
+                        for request_id, curie_mapping in request_curie_mapping.items():
                             filtered_msg = filter_by_curie_mapping(
                                 message, curie_mapping, kp_id=self.id
                             )
@@ -292,15 +292,22 @@ class ThrottledServer:
                             response_values[request_id] = ReasonerResponse(
                                 message=filtered_msg
                             )
-                        except BatchingError as err:
-                            # the response is probably malformed
-                            response_values[request_id] = err
+                except Exception as err:
+                    # Raise more descriptive error message of response message parsing
+                    raise Exception(
+                        "[{}] Failed to parse message response: {} with Error: {}".format(
+                            self.id,
+                            response.json(),
+                            err,
+                        )
+                    )
             except (
                 asyncio.exceptions.TimeoutError,
                 httpx.RequestError,
                 httpx.HTTPStatusError,
                 JSONDecodeError,
                 pydantic.ValidationError,
+                Exception,
             ) as e:
                 for request_id, curie_mapping in request_curie_mapping.items():
                     response_values[request_id] = ReasonerResponse(

--- a/strider/trapi_throttle/throttle.py
+++ b/strider/trapi_throttle/throttle.py
@@ -270,14 +270,17 @@ class ThrottledServer:
                     if len(request_curie_mapping) == 1:
                         request_id = next(iter(request_curie_mapping))
                         # Make a copy
-                        response_values[request_id] = ReasonerResponse(message=Message())
+                        response_values[request_id] = ReasonerResponse(
+                            message=Message()
+                        )
                         response_values[
                             request_id
                         ].message.query_graph = request_value_mapping[
                             request_id
                         ].message.query_graph.copy()
                         response_values[request_id].message.knowledge_graph = (
-                            message.knowledge_graph or KnowledgeGraph(nodes={}, edges={})
+                            message.knowledge_graph
+                            or KnowledgeGraph(nodes={}, edges={})
                         ).copy()
                         response_values[request_id].message.results = (
                             message.results or HashableSet(__root__=[])
@@ -288,7 +291,9 @@ class ThrottledServer:
                             filtered_msg = filter_by_curie_mapping(
                                 message, curie_mapping, kp_id=self.id
                             )
-                            filtered_msg.query_graph = request_value_mapping[request_id].message.query_graph.copy()
+                            filtered_msg.query_graph = request_value_mapping[
+                                request_id
+                            ].message.query_graph.copy()
                             response_values[request_id] = ReasonerResponse(
                                 message=filtered_msg
                             )

--- a/tests/helpers/context.py
+++ b/tests/helpers/context.py
@@ -122,6 +122,8 @@ async def translator_overlay(
                 metakg = response.json()
             kps[host] = {
                 "url": f"http://{host}/query",
+                "infores": host,
+                "maturity": "development",
                 "operations": [
                     {
                         "subject_category": edge["subject"],

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -38,6 +38,8 @@ def create_kp(args):
     source, edge, target = args
     return {
         "url": "http://mykp",
+        "infores": "mykp",
+        "maturity": "development",
         "operations": [
             {
                 "subject_category": source,
@@ -360,6 +362,8 @@ def kps_from_string(s):
         if name not in kps:
             kps[name] = {
                 "url": f"http://{name}",
+                "infores": name,
+                "maturity": "development",
                 "operations": [],
             }
         kps[name]["operations"].append(

--- a/tests/test_kp_responses.py
+++ b/tests/test_kp_responses.py
@@ -63,11 +63,7 @@ setup_logger()
     "http://ctd/query",
     Response(
         status_code=200,
-        content=json.dumps(
-            {
-                "message": {}
-            }
-        ),
+        content=json.dumps({"message": {}}),
     ),
 )
 async def test_kp_response_empty_message(client):
@@ -85,9 +81,7 @@ async def test_kp_response_empty_message(client):
 
     # Create query
     q = {
-        "message": {
-            "query_graph": QGRAPH
-        },
+        "message": {"query_graph": QGRAPH},
         # "log_level": "WARNING"
     }
 
@@ -163,9 +157,7 @@ async def test_kp_response_empty_message_pinned_two_hop(client):
 
     # Create query
     q = {
-        "message": {
-            "query_graph": QGRAPH
-        },
+        "message": {"query_graph": QGRAPH},
         "log_level": "WARNING",
     }
 

--- a/tests/test_kp_responses.py
+++ b/tests/test_kp_responses.py
@@ -1,0 +1,176 @@
+"""Test weird kp responses."""
+import fakeredis
+import httpx
+import json
+import pytest
+
+from fastapi.responses import Response
+
+from tests.helpers.context import (
+    with_translator_overlay,
+    with_registry_overlay,
+    with_norm_overlay,
+    with_response_overlay,
+)
+from tests.helpers.logger import setup_logger
+from tests.helpers.utils import query_graph_from_string
+
+from strider.server import APP
+from strider.config import settings
+from strider.storage import get_client
+
+# Switch prefix path before importing server
+settings.kpregistry_url = "http://registry"
+settings.normalizer_url = "http://normalizer"
+
+APP.dependency_overrides[get_client] = lambda: fakeredis.FakeRedis(
+    encoding="utf-8",
+    decode_responses=True,
+)
+
+
+@pytest.fixture()
+async def client():
+    """Yield httpx client."""
+    async with httpx.AsyncClient(app=APP, base_url="http://test") as client_:
+        yield client_
+
+
+setup_logger()
+
+
+@pytest.mark.asyncio
+@with_norm_overlay(settings.normalizer_url)
+@with_registry_overlay(
+    settings.kpregistry_url,
+    {
+        "ctd": {
+            "url": "http://ctd/query",
+            "infores": "strider",
+            "maturity": "development",
+            "operations": [
+                {
+                    "subject_category": "biolink:ChemicalSubstance",
+                    "predicate": "biolink:treats",
+                    "object_category": "biolink:Disease",
+                }
+            ],
+            "details": {"preferred_prefixes": {}},
+        }
+    },
+)
+@with_response_overlay(
+    "http://ctd/query",
+    Response(
+        status_code=200,
+        content=json.dumps(
+            {
+                "message": {}
+            }
+        ),
+    ),
+)
+async def test_kp_response_empty_message(client):
+    """
+    Test when a KP returns null query graph.
+    """
+    QGRAPH = query_graph_from_string(
+        """
+        n0(( categories[] biolink:ChemicalSubstance ))
+        n0(( ids[] CHEBI:6801 ))
+        n0-- biolink:treats -->n1
+        n1(( category biolink:Disease ))
+        """
+    )
+
+    # Create query
+    q = {
+        "message": {
+            "query_graph": QGRAPH
+        },
+        # "log_level": "WARNING"
+    }
+
+    # Run
+    response = await client.post("/query", json=q)
+    output = response.json()
+    assert "knowledge_graph" in output["message"]
+    assert "results" in output["message"]
+
+
+@pytest.mark.asyncio
+@with_norm_overlay(settings.normalizer_url)
+@with_translator_overlay(
+    settings.kpregistry_url,
+    settings.normalizer_url,
+    kp_data={
+        "kp0": """
+            MONDO:1(( category biolink:Disease ))
+            MONDO:1-- predicate biolink:related_to -->Gene:1
+            MONDO:1-- predicate biolink:related_to -->Gene:2
+            Gene:1(( category biolink:Gene ))
+            Gene:2(( category biolink:Gene ))
+            MONDO:2(( category biolink:Disease ))
+            MONDO:2-- predicate biolink:related_to -->Gene:1
+            MONDO:2-- predicate biolink:related_to -->Gene:2
+        """,
+        "kp1": """
+            MONDO:1(( category biolink:Disease ))
+            MONDO:1-- predicate biolink:related_to -->Gene:1
+            Gene:1(( category biolink:Gene ))
+            Gene:1-- predicate biolink:related_to -->MONDO:2
+            MONDO:2(( category biolink:Disease ))
+        """,
+        "kp2": """
+            MONDO:1(( category biolink:Disease ))
+            MONDO:1-- predicate biolink:related_to -->Gene:1
+            Gene:1(( category biolink:Gene ))
+            Gene:1-- predicate biolink:related_to -->MONDO:2
+            MONDO:2(( category biolink:Disease ))
+        """,
+    },
+    normalizer_data="""
+        MONDO:1 categories biolink:Disease
+        Gene:1 categories biolink:Gene
+        MONDO:2 categories biolink:Disease
+        """,
+)
+@with_response_overlay(
+    "http://kp1/query",
+    Response(
+        status_code=200,
+        content=json.dumps(
+            {
+                "message": {},
+            }
+        ),
+    ),
+)
+async def test_kp_response_empty_message_pinned_two_hop(client):
+    """
+    Test when a KP returns null query graph.
+    """
+    QGRAPH = query_graph_from_string(
+        """
+        n0(( ids[] MONDO:1 ))
+        n0-- biolink:related_to -->n1
+        n1(( category biolink:Gene ))
+        n1-- biolink:related_to -->n2
+        n2(( ids[] MONDO:2 ))
+
+        """
+    )
+
+    # Create query
+    q = {
+        "message": {
+            "query_graph": QGRAPH
+        },
+        "log_level": "WARNING",
+    }
+
+    # Run
+    response = await client.post("/query", json=q)
+    output = response.json()
+    assert len(output["logs"]) == 1
+    assert output["logs"][0]["message"] == "Something went wrong while querying kp1"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -606,6 +606,8 @@ async def test_kp_500(client):
     {
         "ctd": {
             "url": "http://ctd/query",
+            "infores": "ctd",
+            "maturity": "development",
             "operations": [
                 {
                     "subject_category": "biolink:ChemicalSubstance",
@@ -652,6 +654,8 @@ async def test_kp_unavailable(client):
     {
         "ctd": {
             "url": "http://ctd/query",
+            "infores": "ctd",
+            "maturity": "development",
             "operations": [
                 {
                     "subject_category": "biolink:ChemicalSubstance",
@@ -754,6 +758,8 @@ async def test_kp_no_kg(client):
     {
         "ctd": {
             "url": "http://ctd/query",
+            "infores": "ctd",
+            "maturity": "development",
             "operations": [
                 {
                     "subject_category": "biolink:ChemicalSubstance",


### PR DESCRIPTION
There are a few things that this PR takes care of:
- Even when there were no curies in the message, we were sending an empty list to Node Norm, who would error. There are now checks for an empty list and we won't send the request.
- We've bumped reasoner-pydantic versions to fix some validation issues
- I removed the pinned kp-registry and binder versions in our testing requirements so we're using the most recent. I also updated the tests because they were using an old kp-registry version.
- To fix the strider hanging issue, I added a debug call stack so we can hopefully find any hangs in the future easier. I also added a generic `Exception` handler to the throttle so we handle errors more gracefully.