### PR TITLE
Improve performance

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -38,7 +38,7 @@ protobuf==3.20.3
 pydantic==1.10.6
 python-dotenv==0.17.0
 PyYAML==5.4
-reasoner-pydantic==4.0.6
+reasoner-pydantic==4.0.7
 redis==4.3.4
 rfc3986==1.5.0
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ uvicorn[standard]==0.14.0
 jsonpickle==1.4.2
 python-dotenv==0.17.0
 fastapi==0.65.2
-reasoner-pydantic==4.0.6
+reasoner-pydantic==4.0.7
 redis==4.3.4
 orjson==3.6.0
 yappi==1.3.2

--- a/strider/config.py
+++ b/strider/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     max_process_time: int = 3400
     redis_host: str = "localhost"
     redis_port: int = 6379
-    redis_expiration: int = 604800  # one week
+    redis_expiration: int = 1209600  # two weeks
     redis_password: str = "supersecretpassword"
 
     jaeger_enabled: str = "True"

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -107,7 +107,9 @@ class Binder:
         self.logger.info(f"Current call stack: {(', ').join(call_stack)}")
         onehop_response = await get_kp_onehop(kp.id, onehop_qgraph)
         if onehop_response is not None:
-            self.logger.info(f"[{kp.id}]: Got onehop from cache")
+            self.logger.info(
+                f"[{kp.id}]: Got onehop with {len(onehop_response['results'])} results from cache"
+            )
         if onehop_response is None and not settings.offline_mode:
             # onehop not in cache, have to go get response
             self.logger.info(

--- a/strider/server.py
+++ b/strider/server.py
@@ -445,7 +445,7 @@ async def lookup(
         }
 
     # Result container to make result merging much faster
-    output_results = HashableMapping[Result, Result]()
+    output_results = HashableMapping[str, Result]()
 
     output_kgraph = KnowledgeGraph.parse_obj({"nodes": {}, "edges": {}})
 
@@ -470,13 +470,14 @@ async def lookup(
             # Update the results
             # hashmap lookup is very quick
             sub_result = next(iter(result_message.results))
-            existing_result = output_results.get(sub_result, None)
+            sub_result_hash = hash(sub_result)
+            existing_result = output_results.get(sub_result_hash, None)
             if existing_result:
                 # update existing result
                 existing_result.update(sub_result)
             else:
                 # add new result to hashmap
-                output_results[sub_result] = sub_result
+                output_results[sub_result_hash] = sub_result
 
     for result in output_results.values():
         if len(result.analyses) > 1:

--- a/strider/server.py
+++ b/strider/server.py
@@ -27,7 +27,7 @@ from reasoner_pydantic import (
     AsyncQuery,
     Message,
     Response as ReasonerResponse,
-    Results,
+    AuxiliaryGraphs,
 )
 
 from .caching import save_kp_registry, get_registry_lock, remove_registry_lock

--- a/strider/server.py
+++ b/strider/server.py
@@ -27,6 +27,7 @@ from reasoner_pydantic import (
     AsyncQuery,
     Message,
     Response as ReasonerResponse,
+    Results,
     AuxiliaryGraphs,
 )
 
@@ -480,15 +481,17 @@ async def lookup(
                 # add new result to hashmap
                 output_results[sub_result_hash] = sub_result
 
+    results = Results.parse_obj([])
     for result in output_results.values():
         if len(result.analyses) > 1:
             result.combine_analyses_by_resource_id()
+        results.add(result)
 
     output_query = Query(
         message=Message(
             query_graph=QueryGraph.parse_obj(qgraph),
             knowledge_graph=output_kgraph,
-            results=HashableSet[Result](__root__=set(output_results.values())),
+            results=results,
             auxiliary_graphs=output_auxgraphs,
         )
     )

--- a/strider/server.py
+++ b/strider/server.py
@@ -57,7 +57,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="4.3.2",
+    version="4.3.3",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/strider/server.py
+++ b/strider/server.py
@@ -448,6 +448,7 @@ async def lookup(
 
     output_kgraph = KnowledgeGraph.parse_obj({"nodes": {}, "edges": {}})
 
+    output_auxgraphs = AuxiliaryGraphs.parse_obj({})
     async with binder:
         async for result_kgraph_dict, result, result_auxgraph in binder.lookup(None):
             result_message = Message.parse_obj(

--- a/strider/server.py
+++ b/strider/server.py
@@ -332,7 +332,8 @@ async def sync_query(
         }
 
     # Return results
-    num_results = len(query_results.get("message", {}).get("results", []))
+    msg = query_results.get("message") or {}
+    num_results = len(msg.get("results") or [])
     LOGGER.info(f"[{qid}] Returning sync query with {num_results} results")
     return JSONResponse(query_results)
 

--- a/strider/server.py
+++ b/strider/server.py
@@ -481,9 +481,7 @@ async def lookup(
     )
 
     # Collapse sets
-    message_dict = output_query.message.dict()
-    collapse_sets(message_dict)
-    output_query.message = Message.parse_obj(message_dict)
+    collapse_sets(output_query, logger)
 
     output_query.logs = list(log_handler.contents())
     return qid, output_query.dict()

--- a/strider/server.py
+++ b/strider/server.py
@@ -332,7 +332,8 @@ async def sync_query(
         }
 
     # Return results
-    LOGGER.info(f"[{qid}] Returning sync query")
+    num_results = len(query_results.get("message", {}).get("results", []))
+    LOGGER.info(f"[{qid}] Returning sync query with {num_results} results")
     return JSONResponse(query_results)
 
 

--- a/strider/server.py
+++ b/strider/server.py
@@ -449,18 +449,21 @@ async def lookup(
     output_kgraph = KnowledgeGraph.parse_obj({"nodes": {}, "edges": {}})
 
     async with binder:
-        async for result_kgraph_dict, results in binder.lookup(None):
-            # TODO figure out how to remove this conversion
+        async for result_kgraph_dict, result, result_auxgraph in binder.lookup(None):
             result_message = Message.parse_obj(
                 {
                     "knowledge_graph": result_kgraph_dict,
-                    "results": [results],
+                    "results": [result],
+                    "auxiliary_graphs": result_auxgraph,
                 }
             )
             result_message._normalize_kg_edge_ids()
 
             # Update the kgraph
             output_kgraph.update(result_message.knowledge_graph)
+
+            # Update the aux graphs
+            output_auxgraphs.update(result_message.auxiliary_graphs)
 
             # Update the results
             output_results.update(result_message.results)
@@ -473,7 +476,7 @@ async def lookup(
         message=Message(
             query_graph=QueryGraph.parse_obj(qgraph),
             knowledge_graph=output_kgraph,
-            results=output_results,
+            auxiliary_graphs=output_auxgraphs,
         )
     )
 

--- a/strider/server.py
+++ b/strider/server.py
@@ -461,7 +461,6 @@ async def lookup(
                 }
             )
 
-
             # Update the kgraph
             output_kgraph.update(result_message.knowledge_graph)
 

--- a/strider/trapi_throttle/throttle.py
+++ b/strider/trapi_throttle/throttle.py
@@ -259,7 +259,7 @@ class ThrottledServer:
                 response_dict = response.json()
 
                 msg = response_dict.get("message") or {}
-                results = msg.get("results", [])
+                results = msg.get("results") or []
                 num_results = len(results)
                 self.logger.info(
                     "[{}] Received response with {} results in {} seconds".format(

--- a/tests/helpers/redisMock.py
+++ b/tests/helpers/redisMock.py
@@ -1,5 +1,6 @@
 """Mock Redis."""
 import fakeredis.aioredis as fakeredis
+import gzip
 import json
 
 
@@ -151,6 +152,6 @@ async def redisMock(connection_pool=None):
     # Here's where I got documentation for how to do async fakeredis:
     # https://github.com/cunla/fakeredis-py/issues/66#issuecomment-1316045893
     redis = await fakeredis.FakeRedis()
-    await redis.set("kps", json.dumps(default_kps))
+    await redis.set("kps", gzip.compress(json.dumps(default_kps).encode()))
     # set up mock function
     return redis

--- a/tests/test_node_sets.py
+++ b/tests/test_node_sets.py
@@ -1,5 +1,16 @@
 """Test node set handling."""
+import logging
+
+from reasoner_pydantic import (
+    Query,
+    Message,
+    QueryGraph,
+    Results,
+)
+from reasoner_pydantic.utils import HashableSet
 from strider.node_sets import collapse_sets
+
+LOGGER = logging.getLogger(__name__)
 
 
 def test_node_sets():
@@ -57,10 +68,12 @@ def test_node_sets():
             ],
         },
     ]
-    message = {
-        "query_graph": qgraph,
-        "results": results,
-    }
-    collapse_sets(message)
-    assert len(message["results"]) == 2
-    assert len(message["results"][0]["node_bindings"]["n1"]) == 2
+
+    query = Query(
+        message=Message(
+            query_graph=QueryGraph.parse_obj(qgraph),
+            results=Results.parse_obj(results),
+        )
+    )
+    collapse_sets(query, LOGGER)
+    assert len(query.message.results) == 2


### PR DESCRIPTION
This PR is aimed at improving the performance and speed of Strider.

- Testing a creative mode query with 83 sub-queries
  - No Cache: In the previous version, it was approximately 97 minutes to complete all queries, with the new it takes about 20 mins
  - With Cache: previous version I cut it off at 45 mins but I expect it would have taken at least another 15. With the new, it takes about 8 minutes.
- We are now compressing all the entries in redis. This will cut down our storage footprint by ~5x. The plan for deployment is to also bump the redis container up from 10GB to 100GB? With that, we could probably also bump up the TTL on each key from 1 week to something a little longer? @cbizon @kennethmorton do you guys have thoughts on this?