### PR TITLE
Timeout param

### DIFF
--- a/strider/caching.py
+++ b/strider/caching.py
@@ -211,7 +211,5 @@ async def get_post_response(url, request):
 
 async def clear_cache():
     """Clear one-hop redis cache."""
-    client = await aioredis.Redis(
-        connection_pool=onehop_redis_pool
-    )
+    client = await aioredis.Redis(connection_pool=onehop_redis_pool)
     await client.flushdb()

--- a/strider/caching.py
+++ b/strider/caching.py
@@ -207,3 +207,11 @@ async def get_post_response(url, request):
     if response is not None:
         response = json.loads(gzip.decompress(response))
     return response
+
+
+async def clear_cache():
+    """Clear one-hop redis cache."""
+    client = await aioredis.Redis(
+        connection_pool=onehop_redis_pool
+    )
+    await client.flushdb()

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -48,11 +48,12 @@ class Fetcher:
         a full result can be returned for merging.
     """
 
-    def __init__(self, logger):
+    def __init__(self, logger, parameters):
         """Initialize."""
         self.logger: logging.Logger = logger
         self.normalizer = Normalizer(self.logger)
         self.kps = dict()
+        self.parameters = parameters
 
         self.preferred_prefixes = WBMT.entity_prefix_mapping
 
@@ -344,5 +345,6 @@ class Fetcher:
                 kp_id,
                 kp,
                 self.logger,
+                self.parameters,
                 information_content_threshold=information_content_threshold,
             )

--- a/strider/knowledge_provider.py
+++ b/strider/knowledge_provider.py
@@ -48,7 +48,6 @@ class KnowledgeProvider:
             logger=logger,
             preproc=self.get_preprocessor(kp["details"]["preferred_prefixes"]),
             postproc=self.get_postprocessor(WBMT.entity_prefix_mapping),
-            max_batch_size=1,
             parameters=parameters,
             *args,
             *kwargs,

--- a/strider/knowledge_provider.py
+++ b/strider/knowledge_provider.py
@@ -34,6 +34,7 @@ class KnowledgeProvider:
         kp_id,
         kp,
         logger,
+        parameters,
         information_content_threshold: int = settings.information_content_threshold,
         *args,
         **kwargs,
@@ -47,6 +48,8 @@ class KnowledgeProvider:
             logger=logger,
             preproc=self.get_preprocessor(kp["details"]["preferred_prefixes"]),
             postproc=self.get_postprocessor(WBMT.entity_prefix_mapping),
+            max_batch_size=1,
+            parameters=parameters,
             *args,
             *kwargs,
         )

--- a/strider/knowledge_provider.py
+++ b/strider/knowledge_provider.py
@@ -34,7 +34,7 @@ class KnowledgeProvider:
         kp_id,
         kp,
         logger,
-        parameters,
+        parameters: dict = {},
         information_content_threshold: int = settings.information_content_threshold,
         *args,
         **kwargs,

--- a/strider/server.py
+++ b/strider/server.py
@@ -331,10 +331,10 @@ async def sync_query(
     try:
         LOGGER.info(f"[{qid}] Starting sync query")
         # get max timeout
-        timeout = max(max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0))
-        query_results = await asyncio.wait_for(
-            lookup(query_dict, qid), timeout=timeout
+        timeout = max(
+            max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0)
         )
+        query_results = await asyncio.wait_for(lookup(query_dict, qid), timeout=timeout)
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}] Sync query cancelled due to timeout.")
         query_results = {
@@ -342,7 +342,9 @@ async def sync_query(
             "status_communication": {"strider_process_status": "timeout"},
         }
     except Exception as e:
-        LOGGER.error(f"[{qid}] Sync query failed unexpectedly: {traceback.format_exc()}")
+        LOGGER.error(
+            f"[{qid}] Sync query failed unexpectedly: {traceback.format_exc()}"
+        )
         qid = "Exception"
         query_results = {
             "message": {},
@@ -525,10 +527,10 @@ async def async_lookup(
     query_results = {}
     try:
         # get max timeout
-        timeout = max(max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0))
-        query_results = await asyncio.wait_for(
-            lookup(query_dict, qid), timeout=timeout
+        timeout = max(
+            max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0)
         )
+        query_results = await asyncio.wait_for(lookup(query_dict, qid), timeout=timeout)
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}]: Process cancelled due to timeout.")
         query_results = {
@@ -558,7 +560,10 @@ async def multi_lookup(multiqid, callback, queries: dict, query_keys: list):
         query_result = {}
         try:
             # get max timeout
-            timeout = max(max_process_time, queries[query_key].get("parameters", {}).get("timeout_seconds", 0))
+            timeout = max(
+                max_process_time,
+                queries[query_key].get("parameters", {}).get("timeout_seconds", 0),
+            )
             query_result = await asyncio.wait_for(
                 lookup(queries[query_key], qid), timeout=timeout
             )

--- a/strider/server.py
+++ b/strider/server.py
@@ -331,9 +331,9 @@ async def sync_query(
     try:
         LOGGER.info(f"[{qid}] Starting sync query")
         # get max timeout
-        timeout = max(
-            max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0)
-        )
+        timeout_seconds = (query_dict.get("parameters") or {}).get("timeout_seconds")
+        timeout_seconds = timeout_seconds if type(timeout_seconds) is int else 0
+        timeout = max(max_process_time, timeout_seconds)
         query_results = await asyncio.wait_for(lookup(query_dict, qid), timeout=timeout)
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}] Sync query cancelled due to timeout.")
@@ -448,7 +448,7 @@ async def lookup(
     logger.setLevel(level_number)
     logger.addHandler(log_handler)
 
-    parameters = query_dict.get("parameters", {})
+    parameters = query_dict.get("parameters") or {}
 
     fetcher = Fetcher(logger, parameters)
 
@@ -527,9 +527,9 @@ async def async_lookup(
     query_results = {}
     try:
         # get max timeout
-        timeout = max(
-            max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0)
-        )
+        timeout_seconds = (query_dict.get("parameters") or {}).get("timeout_seconds")
+        timeout_seconds = timeout_seconds if type(timeout_seconds) is int else 0
+        timeout = max(max_process_time, timeout_seconds)
         query_results = await asyncio.wait_for(lookup(query_dict, qid), timeout=timeout)
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}]: Process cancelled due to timeout.")
@@ -560,10 +560,11 @@ async def multi_lookup(multiqid, callback, queries: dict, query_keys: list):
         query_result = {}
         try:
             # get max timeout
-            timeout = max(
-                max_process_time,
-                queries[query_key].get("parameters", {}).get("timeout_seconds", 0),
+            timeout_seconds = (queries[query_key].get("parameters") or {}).get(
+                "timeout_seconds"
             )
+            timeout_seconds = timeout_seconds if type(timeout_seconds) is int else 0
+            timeout = max(max_process_time, timeout_seconds)
             query_result = await asyncio.wait_for(
                 lookup(queries[query_key], qid), timeout=timeout
             )

--- a/strider/server.py
+++ b/strider/server.py
@@ -72,7 +72,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="4.4.5",
+    version="4.4.6",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/strider/server.py
+++ b/strider/server.py
@@ -328,8 +328,10 @@ async def sync_query(
     qid = str(uuid.uuid4())[:8]
     try:
         LOGGER.info(f"[{qid}] Starting sync query")
+        # get max timeout
+        timeout = max(max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0))
         query_results = await asyncio.wait_for(
-            lookup(query_dict, qid), timeout=max_process_time
+            lookup(query_dict, qid), timeout=timeout
         )
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}] Sync query cancelled due to timeout.")
@@ -442,7 +444,9 @@ async def lookup(
     logger.setLevel(level_number)
     logger.addHandler(log_handler)
 
-    fetcher = Fetcher(logger)
+    parameters = query_dict.get("parameters", {})
+
+    fetcher = Fetcher(logger, parameters)
 
     logger.info(f"Doing lookup for qgraph: {qgraph}")
     try:
@@ -518,8 +522,10 @@ async def async_lookup(
     qid = str(uuid.uuid4())[:8]
     query_results = {}
     try:
+        # get max timeout
+        timeout = max(max_process_time, query_dict.get("parameters", {}).get("timeout_seconds", 0))
         query_results = await asyncio.wait_for(
-            lookup(query_dict, qid), timeout=max_process_time
+            lookup(query_dict, qid), timeout=timeout
         )
     except asyncio.TimeoutError:
         LOGGER.error(f"[{qid}]: Process cancelled due to timeout.")
@@ -549,8 +555,10 @@ async def multi_lookup(multiqid, callback, queries: dict, query_keys: list):
         qid = f"{multiqid}.{str(uuid.uuid4())[:8]}"
         query_result = {}
         try:
+            # get max timeout
+            timeout = max(max_process_time, queries[query_key].get("parameters", {}).get("timeout_seconds", 0))
             query_result = await asyncio.wait_for(
-                lookup(queries[query_key], qid), timeout=max_process_time
+                lookup(queries[query_key], qid), timeout=timeout
             )
         except asyncio.TimeoutError:
             LOGGER.error(f"[{qid}]: Process cancelled due to timeout.")

--- a/strider/server.py
+++ b/strider/server.py
@@ -342,7 +342,7 @@ async def sync_query(
             "status_communication": {"strider_process_status": "timeout"},
         }
     except Exception as e:
-        LOGGER.error(f"[{qid}] Sync query failed unexpectedly: {e}")
+        LOGGER.error(f"[{qid}] Sync query failed unexpectedly: {traceback.format_exc()}")
         qid = "Exception"
         query_results = {
             "message": {},

--- a/strider/throttle.py
+++ b/strider/throttle.py
@@ -64,6 +64,7 @@ class ThrottledServer:
         preproc: Callable = anull,
         postproc: Callable = anull,
         logger: logging.Logger = None,
+        parameters: dict = {},
         **kwargs,
     ):
         """Initialize."""
@@ -75,6 +76,7 @@ class ThrottledServer:
         self.preproc = preproc
         self.postproc = postproc
         self.use_cache = settings.use_cache
+        self.parameters = parameters
         if logger is None:
             logger = logging.getLogger(__name__)
         self.logger = logger
@@ -211,7 +213,8 @@ class ThrottledServer:
                         ),
                     )
                 )
-                async with httpx.AsyncClient(timeout=settings.kp_timeout) as client:
+                kp_timeout = self.parameters.get("timeout_seconds", settings.kp_timeout)
+                async with httpx.AsyncClient(timeout=kp_timeout) as client:
                     response = await client.post(
                         self.url,
                         json=merged_request_value,

--- a/strider/throttle.py
+++ b/strider/throttle.py
@@ -213,7 +213,10 @@ class ThrottledServer:
                         ),
                     )
                 )
-                kp_timeout = self.parameters.get("timeout_seconds", settings.kp_timeout)
+                kp_timeout = self.parameters.get("timeout_seconds")
+                kp_timeout = (
+                    kp_timeout if type(kp_timeout) is int else settings.kp_timeout
+                )
                 async with httpx.AsyncClient(timeout=kp_timeout) as client:
                     response = await client.post(
                         self.url,


### PR DESCRIPTION
Adds a check for `timeout_seconds` inside of request `parameters` sent from Aragorn. This will enable Strider to take longer for kp lookups to provide more thorough answers that get cached in Aragorn.

We're also adding a `/clear_cache` endpoint so someone can easily clear the onehop cache.