### PR TITLE
Add error handling for cache connection errors

### DIFF
--- a/strider/caching.py
+++ b/strider/caching.py
@@ -185,17 +185,13 @@ async def get_kp_registry():
 
 async def get_registry_lock():
     """Lock registry lookup so only one worker will retrieve."""
-    try:
-        client = await aioredis.Redis(connection_pool=kp_redis_pool)
-        locked = await client.get("locked")
-        if locked is None:
-            await client.setex("locked", 360, 1)
-            await client.close()
-            return True
+    client = await aioredis.Redis(connection_pool=kp_redis_pool)
+    locked = await client.get("locked")
+    if locked is None:
+        await client.setex("locked", 360, 1)
         await client.close()
-    except Exception:
-        # failed to retrieve registry lock
-        pass
+        return True
+    await client.close()
     return False
 
 

--- a/strider/fetcher.py
+++ b/strider/fetcher.py
@@ -436,7 +436,7 @@ class Fetcher:
     async def setup(
         self,
         qgraph: dict,
-        registry: Registry,
+        backup_kps: dict,
         information_content_threshold: int,
     ):
         """Set up."""
@@ -457,8 +457,8 @@ class Fetcher:
         # Generate traversal plan
         self.plan, kps = await generate_plan(
             self.qgraph,
+            backup_kps=backup_kps,
             logger=self.logger,
-            registry=registry,
         )
         self.logger.info(f"Generated query plan: {self.plan}")
 

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -229,7 +229,9 @@ async def generate_plan(
     plan = dict()
     registry = await get_kp_registry()
     if registry is None:
-        logger.warning("Unable to get kp registry from cache. Retrieving in real time...")
+        logger.warning(
+            "Unable to get kp registry from cache. Retrieving in real time..."
+        )
         kp_registry = Registry()
         registry = await kp_registry.retrieve_kps()
     for qedge_id in qgraph["edges"]:

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -7,8 +7,6 @@ import logging
 import math
 from typing import Generator, Union
 
-from kp_registry import Registry
-
 from strider.caching import get_kp_registry
 from strider.config import settings
 from strider.traversal import get_traversals, NoAnswersError
@@ -216,8 +214,8 @@ def get_kp_operations_queries(
 
 async def generate_plan(
     qgraph: dict,
+    backup_kps=dict,
     logger: logging.Logger = None,
-    registry=None,
 ) -> tuple[dict[str, list[str]], dict[str, dict]]:
     """Generate traversal plan."""
     # check that qgraph is traversable
@@ -230,10 +228,9 @@ async def generate_plan(
     registry = await get_kp_registry()
     if registry is None:
         logger.warning(
-            "Unable to get kp registry from cache. Retrieving in real time..."
+            "Unable to get kp registry from cache. Falling back to in-memory registry..."
         )
-        kp_registry = Registry()
-        registry = await kp_registry.retrieve_kps()
+        registry = backup_kps
     for qedge_id in qgraph["edges"]:
         qedge = qgraph["edges"][qedge_id]
         provided_by = {"allowlist": None, "denylist": None} | qedge.pop(

--- a/strider/query_planner.py
+++ b/strider/query_planner.py
@@ -7,6 +7,8 @@ import logging
 import math
 from typing import Generator, Union
 
+from kp_registry import Registry
+
 from strider.caching import get_kp_registry
 from strider.config import settings
 from strider.traversal import get_traversals, NoAnswersError
@@ -227,9 +229,9 @@ async def generate_plan(
     plan = dict()
     registry = await get_kp_registry()
     if registry is None:
-        msg = f"Failed to get kp registry."
-        logger.info(msg)
-        raise NoAnswersError(msg)
+        logger.warning("Unable to get kp registry from cache. Retrieving in real time...")
+        kp_registry = Registry()
+        registry = await kp_registry.retrieve_kps()
     for qedge_id in qgraph["edges"]:
         qedge = qgraph["edges"][qedge_id]
         provided_by = {"allowlist": None, "denylist": None} | qedge.pop(


### PR DESCRIPTION
One thing to note is that if the cache isn't available, Strider will get a new registry of kps for every single query. This is very suboptimal, but would allow us to respond in real time until we could get the redis back up.