### PR TITLE
Change kp refresh function name and pin redis version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     environment:
       REDIS_HOST: ${REDIS_HOST:-redis}
   redis:
-    image: redis/redis-stack-server:latest
     container_name: redis
     build:
       context: redis

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis
+FROM redis/redis-stack-server:7.2.0-v11
 COPY redis.conf /usr/local/etc/redis/redis.conf
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -44,7 +44,7 @@ python-dotenv==1.0.1
 python-multipart==0.0.9
 PyYAML==6.0.1
 reasoner-pydantic==5.0.4
-redis==4.3.4
+redis==5.0.6
 rich==13.7.1
 setuptools==70.0.0
 shellingham==1.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyyaml==6.0.1
 uvicorn[standard]==0.29.0
 fastapi==0.111.0
 reasoner-pydantic==5.0.4
-redis==4.3.4
+redis==5.0.6
 orjson==3.10.3
 gunicorn==22.0.0
 kp-registry==4.0.1

--- a/strider/server.py
+++ b/strider/server.py
@@ -74,7 +74,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="4.7.2",
+    version="4.7.3",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/strider/server.py
+++ b/strider/server.py
@@ -186,7 +186,7 @@ if settings.jaeger_enabled == "True":
 
 
 @APP.on_event("startup")
-async def get_kp_registry():
+async def refresh_kp_registry():
     if not settings.offline_mode:
         await reload_kp_registry()
 


### PR DESCRIPTION
The watchdog tests have been failing for a little while because the /kps endpoint was returning a 500. This fixes that.